### PR TITLE
【Rails&Next.js】チンチラプロフィールページ及びプロフィール編集画面の作成

### DIFF
--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -21,6 +21,7 @@ class Api::V1::ChinchillasController < ApplicationController
     chinchilla.user_id = current_api_v1_user.id
 
     if chinchilla.save!
+      # 成功した場合、ステータス201を返す
       render json: chinchilla, status: :created
     else
       #エラー文を取得し、ステータス422を返す
@@ -31,7 +32,8 @@ class Api::V1::ChinchillasController < ApplicationController
   def update
     chinchilla = Chinchilla.find(params[:id])
     if chinchilla = chinchilla.update!(chinchilla_params)
-      render json: chinchilla
+      # 成功した場合、ステータス204を返す
+      render json: chinchilla,status: :no_content
     else
       #エラー文を取得し、ステータス422を返す
       render json: chinchilla.errors, status: :unprocessable_entity

--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -9,6 +9,12 @@ class Api::V1::ChinchillasController < ApplicationController
     render json: chinchillas
   end
 
+  # チンチラ個別プロフィール
+  def show
+    chinchilla = Chinchilla.find(params[:id])
+    render json:chinchilla
+  end
+
   # チンチラプロフィール作成
   def create
     chinchilla = Chinchilla.new(chinchilla_params)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
       # チンチラプロフィール一覧
       get '/chinchillas', to: 'chinchillas#index'
+      # チンチラ個別プロフィール
+      get '/chinchillas/:id', to: 'chinchillas#show'
       # チンチラプロフィール作成
       post '/chinchillas', to: 'chinchillas#create'
       # チンチラプロフィール更新

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState, useContext } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { getChinchilla } from 'src/lib/api/chinchilla'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
+export const ChinchillaProfilePage = () => {
+  const router = useRouter()
+  const [selectedChinchilla, setSelectedChinchilla] = useState([])
+  const { chinchillaId } = useContext(SelectedChinchillaIdContext)
+
+  const fetch = async () => {
+    try {
+      const res = await getChinchilla(chinchillaId)
+      console.log(res.data)
+      setSelectedChinchilla(res.data)
+    } catch (err) {
+      console.log(err)
+      router.replace('/mychinchilla')
+    }
+  }
+  useEffect(() => {
+    fetch()
+  }, [])
+
+  return (
+    <div>
+      <h1>プロフィール</h1>
+      <Link href="/mychinchilla" passHref>
+        <button>マイチンチラ</button>
+      </Link>
+      <p>コンテキストID：{chinchillaId}</p>
+      <p>フェッチID：{selectedChinchilla.id}</p>
+      <p>名前：{selectedChinchilla.chinchillaName}</p>
+      <p>性別：{selectedChinchilla.chinchillaSex}</p>
+      <p>誕生日：{selectedChinchilla.chinchillaBirthday}</p>
+      <p>お迎え日：{selectedChinchilla.chinchillaMetDay}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -3,12 +3,28 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { getChinchilla } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+import { updateChinchilla } from 'src/lib/api/chinchilla'
 
 export const ChinchillaProfilePage = () => {
   const router = useRouter()
+
+  //選択中のチンチラの状態管理（グローバル）
   const [selectedChinchilla, setSelectedChinchilla] = useState([])
   const { chinchillaId } = useContext(SelectedChinchillaIdContext)
 
+  // 編集モードの状態管理
+  const [isEditing, setIsEditing] = useState(false)
+
+  // 入力内容の状態管理
+  const [chinchillaName, setChinchillaName] = useState(selectedChinchilla.chinchillaName)
+  const [chinchillaSex, setChinchillaSex] = useState(selectedChinchilla.chinchillaSex)
+  const [chinchillaBirthday, setChinchillaBirthday] = useState(
+    selectedChinchilla.chinchillaBirthday
+  )
+  const [chinchillaMetDay, setChinchillaMetDay] = useState(selectedChinchilla.chinchillaMetDay)
+  const params = { chinchillaName, chinchillaSex, chinchillaBirthday, chinchillaMetDay }
+
+  // 選択中のチンチラのデータを取得
   const fetch = async () => {
     try {
       const res = await getChinchilla(chinchillaId)
@@ -19,9 +35,35 @@ export const ChinchillaProfilePage = () => {
       router.replace('/mychinchilla')
     }
   }
+
+  // 初回レンダリング時に選択中のチンチラのデータを取得
   useEffect(() => {
     fetch()
   }, [])
+
+  // 編集内容を保存
+  const handleSave = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await updateChinchilla({
+        chinchillaId,
+        params
+      })
+      console.log(res)
+
+      // ステータス204 no_content
+      if (res.status === 204) {
+        setIsEditing(false)
+        fetch()
+        console.log('チンチラプロフィール更新成功！')
+      } else {
+        alert('チンチラプロフィール更新失敗')
+      }
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
+  }
 
   return (
     <div>
@@ -29,12 +71,96 @@ export const ChinchillaProfilePage = () => {
       <Link href="/mychinchilla" passHref>
         <button>マイチンチラ</button>
       </Link>
-      <p>コンテキストID：{chinchillaId}</p>
-      <p>フェッチID：{selectedChinchilla.id}</p>
-      <p>名前：{selectedChinchilla.chinchillaName}</p>
-      <p>性別：{selectedChinchilla.chinchillaSex}</p>
-      <p>誕生日：{selectedChinchilla.chinchillaBirthday}</p>
-      <p>お迎え日：{selectedChinchilla.chinchillaMetDay}</p>
+      {isEditing ? (
+        <div>
+          <div>
+            <p>
+              <label htmlFor="chinchillaName">
+                名前：
+                <input
+                  value={chinchillaName}
+                  onChange={(event) => setChinchillaName(event.target.value)}
+                />
+              </label>
+            </p>
+          </div>
+          <div>
+            <p>
+              <label htmlFor="chinchillaSex">
+                性別：
+                <select
+                  value={chinchillaSex}
+                  onChange={(event) => setChinchillaSex(event.target.value)}
+                >
+                  性別
+                  <option value="オス">オス</option>
+                  <option value="メス">メス</option>
+                  <option value="不明">不明</option>
+                </select>
+              </label>
+            </p>
+          </div>
+          <div>
+            <p>
+              <label htmlFor="chinchillaBirthday">
+                誕生日：
+                <input
+                  type="date"
+                  value={chinchillaBirthday}
+                  onChange={(event) => setChinchillaBirthday(event.target.value)}
+                />
+              </label>
+            </p>
+          </div>
+          <div>
+            <p>
+              <label htmlFor="chinchillaMetDay">
+                お迎え日：
+                <input
+                  type="date"
+                  value={chinchillaMetDay}
+                  onChange={(event) => setChinchillaMetDay(event.target.value)}
+                />
+              </label>
+            </p>
+          </div>
+          <div>
+            <button
+              onClick={handleSave}
+              disabled={!chinchillaName || !chinchillaSex ? true : false}
+            >
+              保存
+            </button>
+            <button
+              onClick={() => {
+                setIsEditing(false)
+              }}
+            >
+              編集中止
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <p>名前：{selectedChinchilla.chinchillaName}</p>
+          <p>性別：{selectedChinchilla.chinchillaSex}</p>
+          <p>誕生日：{selectedChinchilla.chinchillaBirthday}</p>
+          <p>お迎え日：{selectedChinchilla.chinchillaMetDay}</p>
+          <div>
+            <button
+              onClick={() => {
+                setIsEditing(true)
+                setChinchillaName(selectedChinchilla.chinchillaName)
+                setChinchillaSex(selectedChinchilla.chinchillaSex)
+                setChinchillaBirthday(selectedChinchilla.chinchillaBirthday)
+                setChinchillaMetDay(selectedChinchilla.chinchillaMetDay)
+              }}
+            >
+              編集
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import Link from 'next/link'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 export const MyChinchillaPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   const fetch = async () => {
     const res = await getAllChinchillas()
@@ -21,10 +23,14 @@ export const MyChinchillaPage = () => {
       <Link href="/mypage" passHref>
         <button>マイページ</button>
       </Link>
+      <p>{chinchillaId}</p>
       <div>
         {allChinchillas.map((chinchilla) => (
           <div key={chinchilla.id}>
-            <Link href={`/chinchilla-profile/${chinchilla.id}`} as={'/chinchilla-profile'}>
+            <Link
+              href="/mychinchilla/chinchilla-profile"
+              onClick={() => setChinchillaId(chinchilla.id)}
+            >
               <p>名前：{chinchilla.chinchillaName}</p>
             </Link>
           </div>

--- a/frontend/src/contexts/chinchilla.js
+++ b/frontend/src/contexts/chinchilla.js
@@ -1,0 +1,19 @@
+import { createContext, useState } from 'react'
+
+// グローバルで扱うためにエクスポートする
+export const SelectedChinchillaIdContext = createContext()
+
+//_app.jsにエクスポートして、全体の親にする
+export const ChinchillaProvider = ({ children }) => {
+  const [chinchillaId, setChinchillaId] = useState(0)
+  const value = {
+    chinchillaId,
+    setChinchillaId
+  }
+
+  return (
+    <SelectedChinchillaIdContext.Provider value={value}>
+      {children}
+    </SelectedChinchillaIdContext.Provider>
+  )
+}

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -16,9 +16,9 @@ export const getAllChinchillas = () => {
 }
 
 // チンチラプロフィール一覧(個別)
-export const getChinchilla = () => {
+export const getChinchilla = (chinchillaId) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.get(`/chinchillas/${params.chinchillaId}`, {
+  return client.get(`/chinchillas/${chinchillaId}`, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -40,9 +40,9 @@ export const createChinchilla = (params) => {
 }
 
 // チンチラプロフィール更新
-export const updateChinchilla = (params) => {
+export const updateChinchilla = ({ chinchillaId, params }) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.put(`/chinchillas/${params.chinchillaId}`, params, {
+  return client.put(`/chinchillas/${chinchillaId}`, params, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -1,3 +1,9 @@
+import { ChinchillaProvider } from 'src/contexts/chinchilla'
+
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <ChinchillaProvider>
+      <Component {...pageProps} />
+    </ChinchillaProvider>
+  )
 }

--- a/frontend/src/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -1,0 +1,9 @@
+import { ChinchillaProfilePage } from 'src/components/pages/mychinchilla/chinchilla-profile'
+
+export default function ChinchillaProfile() {
+  return (
+    <>
+      <ChinchillaProfilePage />
+    </>
+  )
+}

--- a/frontend/src/pages/mychinchilla/index.jsx
+++ b/frontend/src/pages/mychinchilla/index.jsx
@@ -1,6 +1,6 @@
 import { MyChinchillaPage } from 'src/components/pages/mychinchilla'
 
-export default function MyPage() {
+export default function MyChinchilla() {
   return (
     <>
       <MyChinchillaPage />


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページを作成し、編集画面でプロフィールを編集・更新できるようにしました。


### 修正前：
- 

### 修正後：
- マイチンチラページ(`/mychinchilla`)に表示された各リンク先(`/mychinchilla/chinchilla-profile`)へ遷移後、当該チンチラの詳細プロフィールを表示
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)の「編集」ボタンを押すとプロフィールが編集可能となり、「保存」ボタンでプロフィールを更新、「編集中止」ボタンで編集可能状態を解除

### 修正理由：
-

## 実装概要
- 【Rails&Next.js】チンチラのプロフィールを取得するAPI作成、表示画面の作成 `385fc4b`
- 【Rails&Next.js】チンチラのプロフィールを更新するAPI修正、編集画面の作成、保存機能の作成 `21646b7`


# スクリーンショット
チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`) 
- 表示画面
![スクリーンショット 2023-08-07 9 14 58](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/13fb5bdf-1323-42e1-a0f6-336df31e83d5)

- 編集画面(編集中)
![スクリーンショット 2023-08-07 9 17 04](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/8d8d2419-0ec5-48ad-832b-5b9d7ccd07bf)

- 保存後
![スクリーンショット 2023-08-07 9 18 30](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/c97879ae-4257-4688-8b1b-00ddbcec09d2)


# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
