### PR TITLE
【Rails&Next.js】チンチラデータ削除機能の作成

### DIFF
--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -1,16 +1,15 @@
 import { useEffect, useState, useContext } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { getChinchilla } from 'src/lib/api/chinchilla'
+import { getChinchilla, updateChinchilla, deleteChinchilla } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
-import { updateChinchilla } from 'src/lib/api/chinchilla'
 
 export const ChinchillaProfilePage = () => {
   const router = useRouter()
 
   //選択中のチンチラの状態管理（グローバル）
   const [selectedChinchilla, setSelectedChinchilla] = useState([])
-  const { chinchillaId } = useContext(SelectedChinchillaIdContext)
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   // 編集モードの状態管理
   const [isEditing, setIsEditing] = useState(false)
@@ -59,6 +58,20 @@ export const ChinchillaProfilePage = () => {
       } else {
         alert('チンチラプロフィール更新失敗')
       }
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
+  }
+
+  //チンチラのデータを削除
+  const handleDelete = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await deleteChinchilla(chinchillaId)
+      console.log(res)
+      setChinchillaId(0)
+      router.replace('/mychinchilla')
     } catch (err) {
       console.log(err)
       alert('エラーです')
@@ -158,6 +171,7 @@ export const ChinchillaProfilePage = () => {
             >
               編集
             </button>
+            <button onClick={handleDelete}>削除</button>
           </div>
         </div>
       )}

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -52,9 +52,9 @@ export const updateChinchilla = ({ chinchillaId, params }) => {
 }
 
 // チンチラプロフィール削除
-export const deleteChinchilla = (params) => {
+export const deleteChinchilla = (chinchillaId) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.delete(`/chinchillas/${params.chinchillaId}`, params, {
+  return client.delete(`/chinchillas/${chinchillaId}`, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),


### PR DESCRIPTION
# 説明
以下のとおりチンチラのデータを削除できるようにしました。


### 修正前：
-

### 修正後：
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)の「削除」ボタンを押すと当該チンチラのデータを削除し、マイチンチラページ(`/mychinchilla`)へリダイレクト

### 修正理由：
-

## 実装概要
- 【Next.js】チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)の修正、削除機能の作成 `5820285`

# スクリーンショット
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)
![スクリーンショット 2023-08-07 15 28 43](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/e3a6dfba-d06a-465a-bcf9-8f47faa35a54)



# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
