### PR TITLE
新規登録ページ及びログインページのデザイン実装

### DIFF
--- a/frontend/src/components/pages/signin/index.jsx
+++ b/frontend/src/components/pages/signin/index.jsx
@@ -35,30 +35,48 @@ export const SignInPage = () => {
   }
 
   return (
-    <div>
-      <h1>ログイン</h1>
-      <Link href="/" passHref>
-        <button>TOPページ</button>
-      </Link>
-      <div>
-        <div>
-          <input
-            placeholder="your@email.com"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </div>
-        <div>
-          <input
-            placeholder="パスワード"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </div>
-        <button onClick={handleSubmit} disabled={!email || !password ? true : false}>
-          ログイン
-        </button>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">ログイン</p>
+      <div className="form-control my-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">メールアドレス</span>
+        </label>
+        <input
+          type="text"
+          placeholder="your@email.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          className="w-ful input input-bordered input-secondary input-md border-dark-pink bg-ligth-white"
+        />
       </div>
+      <div className="form-control mb-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">パスワード</span>
+        </label>
+        <input
+          type="password"
+          placeholder="パスワード"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          className="input input-bordered input-secondary input-md border-dark-pink bg-ligth-white"
+        />
+        <label className="label">
+          <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
+        </label>
+      </div>
+      <button
+        onClick={handleSubmit}
+        disabled={!email || !password ? true : false}
+        className="btn btn-secondary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
+      >
+        ログイン
+      </button>
+      <p className="mb-6 mt-28 text-dark-black">新規登録はこちら</p>
+      <Link href="/signup" passHref>
+        <button className="btn btn-primary mb-40 h-16 w-40 rounded-[10px] text-base tracking-widest text-white">
+          新規登録
+        </button>
+      </Link>
     </div>
   )
 }

--- a/frontend/src/components/pages/signin/index.jsx
+++ b/frontend/src/components/pages/signin/index.jsx
@@ -4,6 +4,9 @@ import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { signIn } from 'src/lib/api/auth'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
+
 export const SignInPage = () => {
   const router = useRouter()
   const [email, setEmail] = useState('')
@@ -34,6 +37,12 @@ export const SignInPage = () => {
     }
   }
 
+  // パスワード表示/非表示切り替え
+  const [isRevealPassword, setIsRevealPassword] = useState(false)
+  const togglePassword = () => {
+    setIsRevealPassword((prevState) => !prevState)
+  }
+
   return (
     <div className="mb-16 mt-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">ログイン</p>
@@ -53,13 +62,24 @@ export const SignInPage = () => {
         <label className="label">
           <span className="text-base text-dark-black">パスワード</span>
         </label>
-        <input
-          type="password"
-          placeholder="パスワード"
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-          className="input input-bordered input-secondary input-md border-dark-pink bg-ligth-white"
-        />
+        <div className="flex items-center">
+          <div className="relative">
+            <input
+              type={isRevealPassword ? 'text' : 'password'}
+              placeholder="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="input input-bordered input-secondary input-md w-96 border-dark-pink bg-ligth-white"
+            />
+            <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
+              {isRevealPassword ? (
+                <FontAwesomeIcon icon={faEye} />
+              ) : (
+                <FontAwesomeIcon icon={faEyeSlash} />
+              )}
+            </span>
+          </div>
+        </div>
         <label className="label">
           <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
         </label>

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -35,30 +35,48 @@ export const SignUpPage = () => {
   }
 
   return (
-    <div>
-      <h1>新規登録</h1>
-      <Link href="/" passHref>
-        <button>TOPページ</button>
-      </Link>
-      <div>
-        <div>
-          <input
-            placeholder="your@email.com"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </div>
-        <div>
-          <input
-            placeholder="パスワード"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </div>
-        <button onClick={handleSubmit} disabled={!email || !password ? true : false}>
-          新規登録
-        </button>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">新規登録</p>
+      <div className="form-control my-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">メールアドレス</span>
+        </label>
+        <input
+          type="text"
+          placeholder="your@email.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+        />
       </div>
+      <div className="form-control mb-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">パスワード</span>
+        </label>
+        <input
+          type="password"
+          placeholder="パスワード"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          className="input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+        />
+        <label className="label">
+          <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
+        </label>
+      </div>
+      <button
+        onClick={handleSubmit}
+        disabled={!email || !password ? true : false}
+        className="btn btn-primary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
+      >
+        新規登録
+      </button>
+      <p className="mb-6 mt-28 text-dark-black">アカウントをお持ちの方はこちら</p>
+      <Link href="/signin" passHref>
+        <button className="btn btn-secondary mb-40 h-16 w-40 rounded-[10px] text-base tracking-widest text-white">
+          ログイン
+        </button>
+      </Link>
     </div>
   )
 }

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -4,6 +4,9 @@ import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { signUp } from 'src/lib/api/auth'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
+
 export const SignUpPage = () => {
   const router = useRouter()
   const [email, setEmail] = useState('')
@@ -34,6 +37,12 @@ export const SignUpPage = () => {
     }
   }
 
+  // パスワード表示/非表示切り替え
+  const [isRevealPassword, setIsRevealPassword] = useState(false)
+  const togglePassword = () => {
+    setIsRevealPassword((prevState) => !prevState)
+  }
+
   return (
     <div className="mb-16 mt-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">新規登録</p>
@@ -53,13 +62,24 @@ export const SignUpPage = () => {
         <label className="label">
           <span className="text-base text-dark-black">パスワード</span>
         </label>
-        <input
-          type="password"
-          placeholder="パスワード"
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-          className="input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
-        />
+        <div className="flex items-center">
+          <div className="relative">
+            <input
+              type={isRevealPassword ? 'text' : 'password'}
+              placeholder="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="input input-bordered input-primary input-md w-96 border-dark-blue bg-ligth-white"
+            />
+            <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
+              {isRevealPassword ? (
+                <FontAwesomeIcon icon={faEye} />
+              ) : (
+                <FontAwesomeIcon icon={faEyeSlash} />
+              )}
+            </span>
+          </div>
+        </div>
         <label className="label">
           <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
         </label>


### PR DESCRIPTION
# 説明
以下のとおり新規登録ページ及びログインページのデザインを実装しました。


### 修正前：
-

### 修正後：
- 新規登録ページ(`/signup`)にて、ログインページ(`/signin`)に遷移するボタンを追加し、デザインを実装しました。
- ログインページ(`/signin`)にて、新規登録ページ(`/signup`)に遷移するボタンを追加し、デザインを実装しました。
- 新規登録ページ(`/signup`)及びログインページ(`/signin`)において、入力したパスワードをデフォルトで非表示にし、iconで表示・非表示を切り替えられるようにしました。

### 修正理由：
-

## 実装概要
- 新規登録ページ(`/signup`)のデザイン実装 `d93624e`
- ログインページ(`/signin`)のデザイン実装 `459fcdc`
- パスワード表示・非表示を切り替えるiconを配置 `9bb6e49`

# スクリーンショット
- 実装前
![スクリーンショット 2023-07-29 18 13 41](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/851c9b1b-f29c-4e90-beed-4a7b575fb802)
![スクリーンショット 2023-07-29 18 13 57](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/425be0d6-afe5-4690-81bb-929f7b4a7bdd)

- 実装後
![スクリーンショット 2023-08-12 0 57 16](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/b6f33bed-3cd9-47b9-8029-d5ca7d31b440)
![スクリーンショット 2023-08-12 0 57 46](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/ca2575f9-1928-4c3b-a424-dec6d2a1ec15)

- パスワード表示・非表示切り替え
![スクリーンショット 2023-08-12 0 59 35](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/936513d9-6622-4afb-9a6c-f84a25568c91)
![スクリーンショット 2023-08-12 0 59 42](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/bcf8a9fb-dac2-4807-87e6-c7f08ee9482c)



# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
