### PR TITLE
ログイン時のみヘッダー・フッターにマイページ及びマイチンチラページのアイコンを表示

### DIFF
--- a/frontend/src/components/pages/mypage/index.jsx
+++ b/frontend/src/components/pages/mypage/index.jsx
@@ -1,10 +1,13 @@
+import { useContext } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { signOut } from 'src/lib/api/auth'
+import { AuthContext } from 'src/contexts/auth'
 
 export const MyPagePage = () => {
   const router = useRouter()
+  const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext)
 
   // ログアウト機能
   const handleSignOut = async (e) => {
@@ -17,6 +20,8 @@ export const MyPagePage = () => {
         Cookies.remove('_client')
         Cookies.remove('_uid')
 
+        setIsSignedIn(false)
+
         router.push('/signin')
         console.log('ログアウトしました！')
       } else {
@@ -28,8 +33,15 @@ export const MyPagePage = () => {
     }
   }
   return (
-    <div>
-      <h1>マイページ</h1>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">マイページ</p>
+      <div>
+        {isSignedIn && currentUser ? (
+          <p>メールアドレス：{currentUser?.email}</p>
+        ) : (
+          <p>Not signed in</p>
+        )}
+      </div>
       <div>
         <Link href="/chinchilla-registration" passHref>
           <button>チンチラの登録</button>

--- a/frontend/src/components/pages/mypage/index.jsx
+++ b/frontend/src/components/pages/mypage/index.jsx
@@ -48,11 +48,6 @@ export const MyPagePage = () => {
         </Link>
       </div>
       <div>
-        <Link href="/mychinchilla" passHref>
-          <button>マイチンチラ</button>
-        </Link>
-      </div>
-      <div>
         <button onClick={handleSignOut}>ログアウト</button>
       </div>
     </div>

--- a/frontend/src/components/pages/signin/index.jsx
+++ b/frontend/src/components/pages/signin/index.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { signIn } from 'src/lib/api/auth'
+import { AuthContext } from 'src/contexts/auth'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -11,6 +12,7 @@ export const SignInPage = () => {
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
 
   // ログイン機能
   const handleSubmit = async (e) => {
@@ -25,6 +27,9 @@ export const SignInPage = () => {
         Cookies.set('_access_token', res.headers['access-token'])
         Cookies.set('_client', res.headers['client'])
         Cookies.set('_uid', res.headers['uid'])
+
+        setIsSignedIn(true)
+        setCurrentUser(res.data.data)
 
         router.push('/mypage')
         console.log('ログイン成功！')

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { signUp } from 'src/lib/api/auth'
+import { AuthContext } from 'src/contexts/auth'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -11,6 +12,7 @@ export const SignUpPage = () => {
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
 
   // 新規登録機能
   const handleSubmit = async (e) => {
@@ -25,6 +27,9 @@ export const SignUpPage = () => {
         Cookies.set('_access_token', res.headers['access-token'])
         Cookies.set('_client', res.headers['client'])
         Cookies.set('_uid', res.headers['uid'])
+
+        setIsSignedIn(true)
+        setCurrentUser(res.data.data)
 
         router.push('/mypage')
         console.log('新規登録成功！')

--- a/frontend/src/components/shared/Footer.jsx
+++ b/frontend/src/components/shared/Footer.jsx
@@ -1,3 +1,23 @@
+import { useContext } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faHouse } from '@fortawesome/free-solid-svg-icons'
+import Link from 'next/link'
+import { AuthContext } from 'src/contexts/auth'
+
 export const Footer = () => {
-  return <footer className="fixed bottom-0 z-10 h-16 w-full bg-dark-blue"></footer>
+  const { isSignedIn, currentUser } = useContext(AuthContext)
+
+  return (
+    <footer className="fixed bottom-0 z-10 h-16 w-full bg-dark-blue">
+      <div className="mx-auto flex h-full max-w-screen-lg place-content-evenly items-center">
+        {isSignedIn && currentUser ? (
+          <Link href="/mychinchilla">
+            <FontAwesomeIcon icon={faHouse} className="text-4xl text-ligth-white" />
+          </Link>
+        ) : (
+          <></>
+        )}
+      </div>
+    </footer>
+  )
 }

--- a/frontend/src/components/shared/Header.jsx
+++ b/frontend/src/components/shared/Header.jsx
@@ -1,29 +1,39 @@
+import { useContext } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPaw } from '@fortawesome/free-solid-svg-icons'
+import { faPaw, faCircleUser } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
+import { AuthContext } from 'src/contexts/auth'
 
 export const Header = () => {
+  const { isSignedIn, currentUser } = useContext(AuthContext)
+
   return (
-    <header className="bg-dark-blue fixed top-0 z-10 h-16 w-full">
+    <header className="fixed top-0 z-10 h-16 w-full bg-dark-blue">
       <div className="mx-auto flex h-full max-w-screen-lg items-center justify-between">
         <div className="ml-12 flex">
-          <FontAwesomeIcon icon={faPaw} className="text-ligth-white  mr-2 text-4xl font-bold" />
-          <Link href="/" className="text-ligth-white text-3xl font-bold">
+          <FontAwesomeIcon icon={faPaw} className="mr-2  text-4xl font-bold text-ligth-white" />
+          <Link href="/" className="text-3xl font-bold text-ligth-white">
             チンチラ
           </Link>
         </div>
-        <div className="mr-12 flex">
-          <Link href="/signup" passHref>
-          <button className="btn btn-primary mr-6 w-28 rounded-[10px] text-base text-white">
-            新規登録
-          </button>
+        {isSignedIn && currentUser ? (
+          <Link href="/mypage">
+            <FontAwesomeIcon icon={faCircleUser} className="mr-32 text-4xl text-ligth-white" />
           </Link>
-          <Link href="/signin" passHref>
-          <button className="btn btn-secondary w-28 rounded-[10px] text-base text-white">
-            ログイン
-          </button>
-          </Link>
-        </div>
+        ) : (
+          <div className="mr-12 flex">
+            <Link href="/signup" passHref>
+              <button className="btn btn-primary mr-6 w-28 rounded-[10px] text-base text-white">
+                新規登録
+              </button>
+            </Link>
+            <Link href="/signin" passHref>
+              <button className="btn btn-secondary w-28 rounded-[10px] text-base text-white">
+                ログイン
+              </button>
+            </Link>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/frontend/src/contexts/auth.js
+++ b/frontend/src/contexts/auth.js
@@ -1,0 +1,38 @@
+import { useState, useEffect, createContext } from 'react'
+import { getCurrentUser } from 'src/lib/api/auth'
+
+// グローバルで扱うためにエクスポートする
+export const AuthContext = createContext({})
+
+//_app.jsにエクスポートして、全体の親にする
+export const AuthProvider = ({ children }) => {
+  const [isSignedIn, setIsSignedIn] = useState(false)
+  const [currentUser, setCurrentUser] = useState()
+  const value = { isSignedIn, setIsSignedIn, currentUser, setCurrentUser }
+
+  // 認証済みのユーザーがいるかどうかチェック
+  // 確認できた場合はそのユーザーの情報を取得
+  const handleGetCurrentUser = async () => {
+    try {
+      const res = await getCurrentUser()
+
+      if (res?.data.isLogin === true) {
+        setIsSignedIn(true)
+        setCurrentUser(res?.data.data)
+
+        console.log(res?.data.data)
+      } else {
+        console.log('No current user')
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  //ログイン状態を監視
+  useEffect(() => {
+    handleGetCurrentUser()
+  }, [setCurrentUser])
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -1,13 +1,16 @@
 import 'src/styles/globals.css'
 import { ChinchillaProvider } from 'src/contexts/chinchilla'
 import { Layout } from 'src/components/shared/layout'
+import { AuthProvider } from 'src/contexts/auth'
 
 export default function App({ Component, pageProps }) {
   return (
-    <ChinchillaProvider>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </ChinchillaProvider>
+    <AuthProvider>
+      <ChinchillaProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </ChinchillaProvider>
+    </AuthProvider>
   )
 }


### PR DESCRIPTION
# 説明
以下のとおりログイン時のみヘッダー・フッターにマイページ及びマイチンチラページのアイコンを表示し、各ページに遷移できるようにしました。

### 修正前：
- ヘッダー：ログイン後も新規登録ページ(`/signup`)及びログインページ(`/signin`)へ遷移するボタンが表示されている。
- フッター：表示なし。

### 修正後：
- ヘッダー：ログイン前は新規登録ページ(`/signup`)及びログインページ(`/signin`)、ログイン後はマイページ(`/mypage`)へ遷移するボタン・アイコンを表示するようにしました。
- フッター：ログイン後はマイチンチラページ(`/mychinchilla`)へ遷移するアイコンを表示するようにしました。

### 修正理由：
- ヘッダー：ログイン後には新規登録ページ(`/signup`)及びログインページ(`/signin`)へ遷移するボタンは不必要であり、ヘッダーにマイページ(`/mypage`)へのアイコンを配置することでへアクセスしやすくなるため。
- フッター：現状、マイページ(`/mypage`)からマイチンチラページ(`/mychinchilla`)に遷移する構造となっており利便性が低く、フッターにマイチンチラページ(`/mychinchilla`)へのアイコンを配置することでへアクセスしやすくなるため。

## 実装概要
- 認証コンテキストを作成し、確認用にログイン中のユーザーのメールアドレスをマイページ(`/mypage`)に表示 `dba6398`
- ログイン前後でヘッダーの表示内容を変更 `6fe4073`
- ログイン前後でフッターの表示内容を変更 `aa54432`
- マイページ(`/mypage`)に配置していたマイチンチラページ(`/mychinchilla`)へのリンクを削除 `893e435`

# スクリーンショット
- ログイン前
![スクリーンショット 2023-08-13 9 31 20](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/157ccbde-c946-43d5-a57a-8949d1af48cd)

- ログイン後
![スクリーンショット 2023-08-13 9 30 31](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/02727c24-6c51-4c07-ad05-7f1d0aa606e1)



# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [x] 仕様変更
