### PR TITLE
チンチラ登録ページのデザイン実装及び遷移ボタンの作成

### DIFF
--- a/frontend/src/components/pages/chinchilla-registration/index.jsx
+++ b/frontend/src/components/pages/chinchilla-registration/index.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { createChinchilla } from 'src/lib/api/chinchilla'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 
 export const ChinchillaRegistrationPage = () => {
   const router = useRouter()
@@ -35,62 +37,76 @@ export const ChinchillaRegistrationPage = () => {
     }
   }
   return (
-    <div>
-      <h1>チンチラの登録</h1>
-      <Link href="/mypage" passHref>
-        <button>マイページ</button>
-      </Link>
-      <div>
-        <div>
-          <label htmlFor="chinchillaName">
-            名前：
-            <input
-              placeholder="チンチラの名前"
-              value={chinchillaName}
-              onChange={(event) => setChinchillaName(event.target.value)}
-            />
-          </label>
-        </div>
-        <div>
-          <label htmlFor="chinchillaSex">
-            性別：
-            <select
-              value={chinchillaSex}
-              onChange={(event) => setChinchillaSex(event.target.value)}
-            >
-              <option hidden value="none">
-                性別
-              </option>
-              <option value="オス">オス</option>
-              <option value="メス">メス</option>
-              <option value="不明">不明</option>
-            </select>
-          </label>
-        </div>
-        <div>
-          <label htmlFor="chinchillaBirthday">
-            誕生日：
-            <input
-              type="date"
-              value={chinchillaBirthday}
-              onChange={(event) => setChinchillaBirthday(event.target.value)}
-            />
-          </label>
-        </div>
-        <div>
-          <label htmlFor="chinchillaMetDay">
-            お迎え日：
-            <input
-              type="date"
-              value={chinchillaMetDay}
-              onChange={(event) => setChinchillaMetDay(event.target.value)}
-            />
-          </label>
-        </div>
-        <button onClick={handleSubmit} disabled={!chinchillaName || !chinchillaSex ? true : false}>
-          登録
-        </button>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">
+        チンチラの登録
+      </p>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">名前</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <input
+          type="text"
+          placeholder="チンチラの名前"
+          value={chinchillaName}
+          onChange={(event) => setChinchillaName(event.target.value)}
+          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+        />
       </div>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">性別</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <select
+          value={chinchillaSex}
+          onChange={(event) => setChinchillaSex(event.target.value)}
+          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-sm font-light text-dark-black"
+        >
+          <option hidden value="">
+            選択してください
+          </option>
+          <option value="オス">オス</option>
+          <option value="メス">メス</option>
+          <option value="不明">不明</option>
+        </select>
+      </div>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">誕生日</span>
+        </label>
+        <input
+          type="date"
+          value={chinchillaBirthday}
+          onChange={(event) => setChinchillaBirthday(event.target.value)}
+          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+        />
+      </div>
+      <div className="form-control mb-12 mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">お迎え日</span>
+        </label>
+        <input
+          type="date"
+          value={chinchillaMetDay}
+          onChange={(event) => setChinchillaMetDay(event.target.value)}
+          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+        />
+      </div>
+      <button
+        onClick={handleSubmit}
+        disabled={!chinchillaName || !chinchillaSex ? true : false}
+        className="btn btn-primary mb-40 h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
+      >
+        登録
+      </button>
     </div>
   )
 }

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -40,7 +40,7 @@ export const MyChinchillaPage = () => {
         ))}
       </div>
       <Link href="/chinchilla-registration" passHref>
-        <button className=" fixed bottom-32 right-40 z-10 grid h-[80px] w-[80px] place-content-center place-items-center rounded-[50%] bg-light-pink">
+        <button className="btn btn-secondary fixed bottom-32 right-40 z-10 grid h-[80px] w-[80px] place-content-center place-items-center rounded-[50%] bg-light-pink">
           <FontAwesomeIcon icon={faPlus} className="absolute top-3 text-4xl text-white" />
           <p className="absolute bottom-3 text-sm text-white">登録</p>
         </button>

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -3,6 +3,9 @@ import Link from 'next/link'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+
 export const MyChinchillaPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
   const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
@@ -36,6 +39,12 @@ export const MyChinchillaPage = () => {
           </div>
         ))}
       </div>
+      <Link href="/chinchilla-registration" passHref>
+        <button className=" fixed bottom-32 right-40 z-10 grid h-[80px] w-[80px] place-content-center place-items-center rounded-[50%] bg-light-pink">
+          <FontAwesomeIcon icon={faPlus} className="absolute top-3 text-4xl text-white" />
+          <p className="absolute bottom-3 text-sm text-white">登録</p>
+        </button>
+      </Link>
     </div>
   )
 }

--- a/frontend/src/components/pages/mypage/index.jsx
+++ b/frontend/src/components/pages/mypage/index.jsx
@@ -43,11 +43,6 @@ export const MyPagePage = () => {
         )}
       </div>
       <div>
-        <Link href="/chinchilla-registration" passHref>
-          <button>チンチラの登録</button>
-        </Link>
-      </div>
-      <div>
         <button onClick={handleSignOut}>ログアウト</button>
       </div>
     </div>


### PR DESCRIPTION
# 説明
以下のとおりチンチラ登録ページ(`/chinchilla-registration`)のデザインを実装し、マイチンチラページ(`/mychinchilla`)から遷移できるようボタンを配置しました。

### 修正前：
- マイページ(`/mypage`)からしかチンチラ登録ページ(`/chinchilla-registration`)に遷移できない。

### 修正後：
- チンチラ登録ページ(`/chinchilla-registration`)のデザインを実装した上で、マイチンチラページ(`/mychinchilla`)からチンチラ登録ページ(`/chinchilla-registration`)へ遷移できるようボタンを配置しました。

### 修正理由：
- チンチラに関する操作(登録、編集等)はマイページ(`/mypage`)と直接関係がなく、利便性が低かったため。

## 実装概要
- チンチラ登録ページ(`/chinchilla-registration`)のデザイン実装 `57fc3a`
- マイチンチラページ(`/mychinchilla`)からチンチラ登録ページ(`/chinchilla-registration`)に遷移できるようボタンを配置 `065d137`
- マイページ(`/mypage`)にあるチンチラ登録ページ(`/chinchilla-registration`)へのリンクを削除 `b68e9cc`
- `065d137`で作成したボタンについて、ホバー時のカラーを修正 `1bc5871`

# スクリーンショット
1. チンチラ登録ページ(`/chinchilla-registration`)
- 実装前
![スクリーンショット 2023-08-02 22 48 55](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/1ddc63f3-a849-4e31-b4f6-8a1c8b0795c3)

- 実装後
![スクリーンショット 2023-08-13 13 06 44](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/ae2a2692-0b3b-4fdc-9456-090d0686461e)

2.  マイチンチラページ(`/mychinchilla`)にチンチラ登録ページ(`/chinchilla-registration`)へ遷移するボタンを配置
- 実装前
![スクリーンショット 2023-08-13 13 09 30](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/79dab1bc-e5fa-4b80-8953-0c4edf0e3ba0)


- 実装後
![スクリーンショット 2023-08-13 12 58 18](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/058ac902-1852-47c3-913c-4254542ac2f3)



# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [x] 仕様変更
