### PR TITLE
ヘッダー左側（アイコン・サービス名）のリンク修正

### DIFF
--- a/frontend/src/components/shared/Header.jsx
+++ b/frontend/src/components/shared/Header.jsx
@@ -10,12 +10,10 @@ export const Header = () => {
   return (
     <header className="fixed top-0 z-10 h-16 w-full bg-dark-blue">
       <div className="mx-auto flex h-full max-w-screen-lg items-center justify-between">
-        <div className="ml-12 flex">
-          <FontAwesomeIcon icon={faPaw} className="mr-2  text-4xl font-bold text-ligth-white" />
-          <Link href="/" className="text-3xl font-bold text-ligth-white">
-            チンチラ
-          </Link>
-        </div>
+        <Link href="/" className="ml-12 flex">
+          <FontAwesomeIcon icon={faPaw} className="mr-2 text-4xl font-bold text-ligth-white" />
+          <p className="text-3xl font-bold text-ligth-white">チンチラ</p>
+        </Link>
         {isSignedIn && currentUser ? (
           <Link href="/mypage">
             <FontAwesomeIcon icon={faCircleUser} className="mr-32 text-4xl text-ligth-white" />


### PR DESCRIPTION
# 説明
以下のとおりヘッダー左側（アイコン・サービス名）を修正し、トップページ(`/`)へアクセスしやすいようにしました。


### 修正前：
- サービス名をクリックするとトップページ(`/`)に遷移するが、アイコンはリンクになっておらずクリックできない。

### 修正後：
- アイコン・サービス名を一体としてクリックできるようにしました。

### 修正理由：
- 現状ではサービス名のみを狙ってクリックする必要があり、利便性が低いため。

## 実装概要
- アイコン・サービス名を一体としてクリックできるように修正 `0c44f2a`


# スクリーンショット
- 


# 変更のタイプ
- [ ] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [x] 仕様変更
