### PR TITLE
マイチンチラページ及びチンチラプロフィールページのデザイン実装

### DIFF
--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState, useContext } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { getChinchilla, updateChinchilla, deleteChinchilla } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 
 export const ChinchillaProfilePage = () => {
   const router = useRouter()
@@ -79,68 +81,71 @@ export const ChinchillaProfilePage = () => {
   }
 
   return (
-    <div>
-      <h1>プロフィール</h1>
-      <Link href="/mychinchilla" passHref>
-        <button>マイチンチラ</button>
-      </Link>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">プロフィール</p>
       {isEditing ? (
-        <div>
-          <div>
-            <p>
-              <label htmlFor="chinchillaName">
-                名前：
-                <input
-                  value={chinchillaName}
-                  onChange={(event) => setChinchillaName(event.target.value)}
-                />
-              </label>
-            </p>
+        <>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">名前</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <input
+              type="text"
+              value={chinchillaName}
+              onChange={(event) => setChinchillaName(event.target.value)}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+            />
           </div>
-          <div>
-            <p>
-              <label htmlFor="chinchillaSex">
-                性別：
-                <select
-                  value={chinchillaSex}
-                  onChange={(event) => setChinchillaSex(event.target.value)}
-                >
-                  性別
-                  <option value="オス">オス</option>
-                  <option value="メス">メス</option>
-                  <option value="不明">不明</option>
-                </select>
-              </label>
-            </p>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">性別</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <select
+              value={chinchillaSex}
+              onChange={(event) => setChinchillaSex(event.target.value)}
+              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-sm font-light text-dark-black"
+            >
+              性別
+              <option value="オス">オス</option>
+              <option value="メス">メス</option>
+              <option value="不明">不明</option>
+            </select>
           </div>
-          <div>
-            <p>
-              <label htmlFor="chinchillaBirthday">
-                誕生日：
-                <input
-                  type="date"
-                  value={chinchillaBirthday}
-                  onChange={(event) => setChinchillaBirthday(event.target.value)}
-                />
-              </label>
-            </p>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">誕生日</span>
+            </label>
+            <input
+              type="date"
+              value={chinchillaBirthday}
+              onChange={(event) => setChinchillaBirthday(event.target.value)}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+            />
           </div>
-          <div>
-            <p>
-              <label htmlFor="chinchillaMetDay">
-                お迎え日：
-                <input
-                  type="date"
-                  value={chinchillaMetDay}
-                  onChange={(event) => setChinchillaMetDay(event.target.value)}
-                />
-              </label>
-            </p>
+          <div className="form-control mb-12 mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">お迎え日</span>
+            </label>
+            <input
+              type="date"
+              value={chinchillaMetDay}
+              onChange={(event) => setChinchillaMetDay(event.target.value)}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white"
+            />
           </div>
-          <div>
+          <div className="mb-40">
             <button
               onClick={handleSave}
               disabled={!chinchillaName || !chinchillaSex ? true : false}
+              className="btn btn-primary mr-24 h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
             >
               保存
             </button>
@@ -148,18 +153,41 @@ export const ChinchillaProfilePage = () => {
               onClick={() => {
                 setIsEditing(false)
               }}
+              className="btn btn-secondary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
             >
-              編集中止
+              戻る
             </button>
           </div>
-        </div>
+        </>
       ) : (
-        <div>
-          <p>名前：{selectedChinchilla.chinchillaName}</p>
-          <p>性別：{selectedChinchilla.chinchillaSex}</p>
-          <p>誕生日：{selectedChinchilla.chinchillaBirthday}</p>
-          <p>お迎え日：{selectedChinchilla.chinchillaMetDay}</p>
-          <div>
+        <>
+          <div className="mt-6 h-[230px] w-[500px] rounded-xl bg-ligth-white">
+            <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">名前</p>
+              <p className="grow text-center text-base text-dark-black">
+                {selectedChinchilla.chinchillaName}
+              </p>
+            </div>
+            <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">性別</p>
+              <p className="grow text-center text-base text-dark-black">
+                {selectedChinchilla.chinchillaSex}
+              </p>
+            </div>
+            <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">誕生日</p>
+              <p className="grow text-center text-base text-dark-black">
+                {selectedChinchilla.chinchillaBirthday}
+              </p>
+            </div>
+            <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">お迎え日</p>
+              <p className="grow text-center text-base text-dark-black">
+                {selectedChinchilla.chinchillaMetDay}
+              </p>
+            </div>
+          </div>
+          <div className="mb-40 mt-12">
             <button
               onClick={() => {
                 setIsEditing(true)
@@ -168,12 +196,18 @@ export const ChinchillaProfilePage = () => {
                 setChinchillaBirthday(selectedChinchilla.chinchillaBirthday)
                 setChinchillaMetDay(selectedChinchilla.chinchillaMetDay)
               }}
+              className="btn btn-primary mr-24 h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
             >
               編集
             </button>
-            <button onClick={handleDelete}>削除</button>
+            <button
+              onClick={handleDelete}
+              className="btn btn-secondary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
+            >
+              削除
+            </button>
           </div>
-        </div>
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -8,7 +8,7 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 
 export const MyChinchillaPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
-  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
+  const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   const fetch = async () => {
     const res = await getAllChinchillas()
@@ -21,20 +21,17 @@ export const MyChinchillaPage = () => {
   }, [])
 
   return (
-    <div>
-      <h1>マイチンチラ</h1>
-      <Link href="/mypage" passHref>
-        <button>マイページ</button>
-      </Link>
-      <p>{chinchillaId}</p>
-      <div>
+    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">マイチンチラ</p>
+      <div className="mt-6 grid grid-cols-2 gap-20">
         {allChinchillas.map((chinchilla) => (
           <div key={chinchilla.id}>
             <Link
               href="/mychinchilla/chinchilla-profile"
               onClick={() => setChinchillaId(chinchilla.id)}
+              className="text-center"
             >
-              <p>名前：{chinchilla.chinchillaName}</p>
+              <p>{chinchilla.chinchillaName}</p>
             </Link>
           </div>
         ))}


### PR DESCRIPTION
# 説明
以下のとおりマイチンチラページ(`/mychinchilla`)及びチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)のデザインを実装しました。


### 修正前：
- マイチンチラページ(`/mychinchilla`):CSSなし、登録されたチンチラ名が１列に並んでいる。
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`):CSSなし。

### 修正後：
- マイチンチラページ(`/mychinchilla`):デザインを実装した上で、登録されたチンチラ名を横２列で表示するように変更しました。
-  チラプロフィールページ(`/mychinchilla/chinchilla-profile`):デザインを実装しました。編集モードの画面では、チンチラ登録ページ(`/chinchilla-registration`)と同じデザイン(#11  )を使用しました。

### 修正理由：
- マイチンチラページ(`/mychinchilla`):今後チンチラの画像登録機能を追加した上で、名前と画像をセットで一覧に表示する予定のため。
-  チラプロフィールページ(`/mychinchilla/chinchilla-profile`):編集モードの画面では、チンチラ登録ページ(`/chinchilla-registration`)と同じデザインとすることで、統一感を持たせるため。

## 実装概要
- マイチンチラページ(`/mychinchilla`)のデザイン実装 `4f47b16`
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)のデザイン実装 `61b0eca`


# スクリーンショット

1. マイチンチラページ(`/mychinchilla`)
- 実装前
<img width="300" alt="スクリーンショット 2023-08-02 22 48 43" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/137098c0-edd0-4854-b593-a42b6d478133">

- 実装後
<img width="300" alt="スクリーンショット 2023-08-14 0 23 21" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/76c95f5f-81e4-4a8e-894a-9a6102442526">


2. チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)
- 実装前（右は編集モード）
<img width="300" alt="スクリーンショット 2023-08-07 9 14 58" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/2b622eef-2ac8-463a-b692-79b44468087e">
<img width="300" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/cdfa1f98-80e5-4243-a3a5-51a6fb07b7ce">

- 実装後（右は編集モード）
<img width="300" alt="スクリーンショット 2023-08-14 0 24 21" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/5bf29173-07e7-42a3-8e77-a3d622a96d81">
<img width="300" alt="スクリーンショット 2023-08-14 0 24 37" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/54dc4d84-f8d9-47a9-817a-8249a33b1050">



# 変更のタイプ
- [ ] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [x] 仕様変更
