### PR TITLE
チンチラの画像を表示させる機能を追加

### DIFF
--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -70,6 +70,17 @@ export const ChinchillaProfilePage = () => {
     setChinchillaImage(file)
   }, [])
 
+  // 編集モードの時に表示する画像
+  const resultImage = () => {
+    if (previewImage) {
+      return previewImage
+    }
+    if (selectedChinchilla.chinchillaImage?.url) {
+      return selectedChinchilla.chinchillaImage.url
+    }
+    return '/images/default.svg'
+  }
+
   // FormData形式でデータを作成
   const createFormData = () => {
     const formData = new FormData()
@@ -128,7 +139,7 @@ export const ChinchillaProfilePage = () => {
           <div className="relative">
             <button onClick={handleClickChangeImage} className=" mt-6">
               <img
-                src={previewImage ? previewImage : '/images/default.svg'}
+                src={resultImage()}
                 alt="プロフィール画像"
                 className="h-[200px] w-[200px] rounded-3xl border border-solid border-dark-blue bg-ligth-white"
               />
@@ -212,6 +223,7 @@ export const ChinchillaProfilePage = () => {
             <button
               onClick={() => {
                 setIsEditing(false)
+                setPreviewImage('')
               }}
               className="btn btn-secondary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
             >
@@ -221,6 +233,17 @@ export const ChinchillaProfilePage = () => {
         </>
       ) : (
         <>
+          <div className="mt-6">
+            <img
+              src={
+                selectedChinchilla.chinchillaImage?.url
+                  ? selectedChinchilla.chinchillaImage.url
+                  : '/images/default.svg'
+              }
+              alt="プロフィール画像"
+              className="h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
+            />
+          </div>
           <div className="mt-6 h-[230px] w-[500px] rounded-xl bg-ligth-white">
             <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
               <p className="w-24 text-center text-base text-dark-black">名前</p>

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -21,9 +21,9 @@ export const MyChinchillaPage = () => {
   }, [])
 
   return (
-    <div className="mb-16 mt-40 grid place-content-center place-items-center">
+    <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">マイチンチラ</p>
-      <div className="mt-6 grid grid-cols-2 gap-20">
+      <div className="mt-6 grid grid-cols-2 gap-x-20 gap-y-14">
         {allChinchillas.map((chinchilla) => (
           <div key={chinchilla.id}>
             <Link
@@ -31,7 +31,18 @@ export const MyChinchillaPage = () => {
               onClick={() => setChinchillaId(chinchilla.id)}
               className="text-center"
             >
-              <p>{chinchilla.chinchillaName}</p>
+              <div>
+                <img
+                  src={
+                    chinchilla.chinchillaImage?.url
+                      ? chinchilla.chinchillaImage.url
+                      : '/images/default.svg'
+                  }
+                  alt="プロフィール画像"
+                  className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
+                />
+                <p className="text-center w-[200px]">{chinchilla.chinchillaName}</p>
+              </div>
             </Link>
           </div>
         ))}


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)及びマイチンチラページ(`/mychinchilla`)でチンチラの画像を表示するようにしました。

### 修正前：
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)：名前、性別、誕生日、お迎え日のみ表示
- マイチンチラページ(`/mychinchilla`)：名前のみ表示

### 修正後：
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)：名前、性別、誕生日、お迎え日に加えて画像を表示しました。
- マイチンチラページ(`/mychinchilla`)：画像と名前をセットでリンクとして表示し、各チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)にアクセスしやすいようにしました。

### 修正理由：
-

## 実装概要
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`) にチンチラの画像を表示する機能を追加 `7c85cac`
- マイチンチラページ(`/mychinchilla`)にチンチラの画像を表示する機能を追加 `6b58c65`

# スクリーンショット
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`) 

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-08-21 12 08 53](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/603ed1dc-9949-45aa-a7df-0e795160568f) | ![スクリーンショット 2023-08-21 12 07 45](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/a1b4cef7-2731-4dd2-a83a-6ea1a61822f7)  |

- マイチンチラページ(`/mychinchilla`) 

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-08-21 12 11 51](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/780a5319-c945-4013-a214-2e7fae6f7edc) | ![スクリーンショット 2023-08-21 12 10 05](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/97ec1ad7-18b8-40c2-90b1-d674829b1a55) |





# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
