### PR TITLE
画像をアップロードした際のバグ（意図しない削除・更新）を修正

### DIFF
--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -85,7 +85,9 @@ export const ChinchillaProfilePage = () => {
   // FormData形式でデータを作成
   const createFormData = () => {
     const formData = new FormData()
-    formData.append('chinchilla[chinchillaImage]', chinchillaImage)
+    if (chinchillaImage) {
+      formData.append('chinchilla[chinchillaImage]', chinchillaImage)
+    }
     formData.append('chinchilla[chinchillaName]', chinchillaName)
     formData.append('chinchilla[chinchillaSex]', chinchillaSex)
     formData.append('chinchilla[chinchillaBirthday]', chinchillaBirthday)

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -109,8 +109,10 @@ export const ChinchillaProfilePage = () => {
 
       // ステータス204 no_content
       if (res.status === 204) {
-        setIsEditing(false)
         fetch()
+        setIsEditing(false)
+        setPreviewImage('')
+        setChinchillaImage('')
         console.log('チンチラプロフィール更新成功！')
       } else {
         alert('チンチラプロフィール更新失敗')
@@ -239,6 +241,7 @@ export const ChinchillaProfilePage = () => {
               onClick={() => {
                 setIsEditing(false)
                 setPreviewImage('')
+                setChinchillaImage('')
               }}
               className="btn btn-secondary h-16 w-40 rounded-[10px] text-base tracking-widest text-white"
             >


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、画像をアップロードした際に発生するバグを修正しました。


### 修正前：
- 画像を選択せずに「保存」ボタンを押すと、画像が削除される。
- 画像を選択した後、保存をせずに「戻る」ボタンを押し、再度「編集」→「保存」ボタンを押すと、画像を編集していなくても前に選択した画像に更新される。

### 修正後：
- 画像を選択した場合のみ、画像を更新するよう修正しました。
- 「戻る」ボタンを押した際に、画像を選択した状態を破棄するよう修正しました。


### 修正理由：
- 画像が選択されていない場合も更新する処理になっており、意図せず画像が削除されてしまったため。
- 画像を選択した後に保存をせず「戻る」ボタンを押した場合も、画像を保持したままの状態になっており、意図せず画像が更新されてしまったため。

## 実装概要
- 画像を選択せずに「保存」ボタンを押すと、画像が削除されるバグを修正 `a949b65`
- 「戻る」ボタンを押した際も、画像を保持したままの状態になっているバグを修正 `84efd14`


# スクリーンショット
- 
| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
