### PR TITLE
チンチラのメモに文字列の「null」が表示されるバグを修正

### DIFF
--- a/frontend/src/components/pages/chinchilla-registration/index.jsx
+++ b/frontend/src/components/pages/chinchilla-registration/index.jsx
@@ -12,6 +12,7 @@ export const ChinchillaRegistrationPage = () => {
   const [chinchillaSex, setChinchillaSex] = useState('')
   const [chinchillaBirthday, setChinchillaBirthday] = useState('')
   const [chinchillaMetDay, setChinchillaMetDay] = useState('')
+  const chinchillaMemo = ''
 
   // プレビュー用
   const [previewImage, setPreviewImage] = useState('')
@@ -49,6 +50,7 @@ export const ChinchillaRegistrationPage = () => {
     formData.append('chinchilla[chinchillaSex]', chinchillaSex)
     formData.append('chinchilla[chinchillaBirthday]', chinchillaBirthday)
     formData.append('chinchilla[chinchillaMetDay]', chinchillaMetDay)
+    formData.append('chinchilla[chinchillaMemo]', chinchillaMemo)
     return formData
   }
 

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -295,7 +295,7 @@ export const ChinchillaProfilePage = () => {
             </div>
             <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
               <p className="whitespace-pre-wrap text-left text-base text-dark-black">
-                {selectedChinchilla.chinchillaMemo ? selectedChinchilla.chinchillaMemo : <></>}
+                {selectedChinchilla.chinchillaMemo}
               </p>
             </div>
           </div>


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、メモに「null」の文字列が表示されるバグを修正しました。


### 修正前：
- チンチラ登録ページ(`/chinchilla-registration`)にメモの入力フォームを用意していないため、チンチラのデータを作成するとメモの初期値がnullになる。
 
### 修正後：
- チンチラ登録時にメモに「''」を登録し、値にnullが入らないように修正しました。

### 修正理由：
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、メモを入力せずに空欄のまま更新すると、文字列の「null」が登録されてしまったため。

## 実装概要
- チンチラ登録時にメモに「''」を登録し、文字列の「null」が登録されるバグを修正 `034c3fa`
-  不要なコードを削除 `b2af985`

# スクリーンショット
- バグの状況
![スクリーンショット 2023-08-23 14 19 52](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/624db589-9515-41ef-a887-a98a5bbf199d) 



# 変更のタイプ
- [ ] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
