### PR TITLE
ログインページ及び新規登録ページの入力フォームにバリデーションを追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@hookform/resolvers": "^3.3.0",
         "autoprefixer": "10.4.14",
         "axios": "^1.4.0",
         "axios-case-converter": "^1.1.0",
@@ -23,7 +24,9 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "tailwindcss": "3.3.3"
+        "react-hook-form": "^7.45.4",
+        "tailwindcss": "3.3.3",
+        "zod": "^3.22.2"
       },
       "devDependencies": {
         "@typescript-eslint/parser": "^6.3.0",
@@ -170,6 +173,14 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.0.tgz",
+      "integrity": "sha512-tgK3nWlfFLlqhqpXZmFMP3RN5E7mlbGfnM2h2ILVsW1TNGuFSod0ePW0grlIY2GAbL4pJdtmOT4HQSZsTwOiKg==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3168,6 +3179,14 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/next/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -3785,6 +3804,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.45.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.4.tgz",
+      "integrity": "sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {
@@ -4726,9 +4760,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@hookform/resolvers": "^3.3.0",
     "autoprefixer": "10.4.14",
     "axios": "^1.4.0",
     "axios-case-converter": "^1.1.0",
@@ -25,7 +26,9 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "3.3.3"
+    "react-hook-form": "^7.45.4",
+    "tailwindcss": "3.3.3",
+    "zod": "^3.22.2"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^6.3.0",

--- a/frontend/src/components/pages/signin/index.jsx
+++ b/frontend/src/components/pages/signin/index.jsx
@@ -5,21 +5,32 @@ import Cookies from 'js-cookie'
 import { signIn } from 'src/lib/api/auth'
 import { AuthContext } from 'src/contexts/auth'
 
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { userSchema } from 'src/validation/validation'
+
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 
 export const SignInPage = () => {
   const router = useRouter()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
   const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
 
+  const {
+    register,
+    handleSubmit,
+    formState: { dirtyFields, errors }
+  } = useForm({
+    defaultValues: { email: '', password: '' },
+    resolver: zodResolver(userSchema)
+  })
+
   // ログイン機能
-  const handleSubmit = async (e) => {
-    e.preventDefault()
+  const onSubmit = async (data) => {
+    const params = { email: data.email, password: data.password }
     try {
-      const res = await signIn({ email, password })
+      const res = await signIn(params)
       console.log(res)
 
       // ステータス200 OK
@@ -52,54 +63,64 @@ export const SignInPage = () => {
   return (
     <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">ログイン</p>
-      <div className="form-control my-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">メールアドレス</span>
-        </label>
-        <input
-          type="text"
-          placeholder="your@email.com"
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          className="w-ful input input-bordered input-secondary input-md border-dark-pink bg-ligth-white text-base text-dark-black"
-        />
-      </div>
-      <div className="form-control mb-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">パスワード</span>
-        </label>
-        <div className="flex items-center">
-          <div className="relative">
-            <input
-              type={isRevealPassword ? 'text' : 'password'}
-              placeholder="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              className="input input-bordered input-secondary input-md w-96 border-dark-pink bg-ligth-white text-base text-dark-black"
-            />
-            <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
-              {isRevealPassword ? (
-                <FontAwesomeIcon icon={faEye} />
-              ) : (
-                <FontAwesomeIcon icon={faEyeSlash} />
+      <form
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+        className="grid place-content-center place-items-center"
+      >
+        <div className="form-control my-6 h-32 w-96">
+          <label htmlFor="email" className="label">
+            <span className="text-base text-dark-black">メールアドレス</span>
+          </label>
+          <input
+            id="email"
+            type="email"
+            {...register('email')}
+            placeholder="your@email.com"
+            className="w-ful input input-bordered input-secondary input-md border-dark-pink bg-ligth-white text-base text-dark-black"
+          />
+          {errors.email && <p className="label text-base text-dark-pink">{errors.email.message}</p>}
+        </div>
+        <div className="form-control mb-12 h-32 w-96">
+          <label htmlFor="password" className="label">
+            <span className="text-base text-dark-black">パスワード</span>
+            <span className="label-text-alt text-sm text-dark-black">6文字以上の半角英数字</span>
+          </label>
+          <div className="flex items-center">
+            <div className="relative">
+              <input
+                id="password"
+                type={isRevealPassword ? 'text' : 'password'}
+                {...register('password')}
+                placeholder="password"
+                className="input input-bordered input-secondary input-md w-96 border-dark-pink bg-ligth-white text-base text-dark-black"
+              />
+              <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
+                {isRevealPassword ? (
+                  <FontAwesomeIcon icon={faEye} />
+                ) : (
+                  <FontAwesomeIcon icon={faEyeSlash} />
+                )}
+              </span>
+              {errors.password && (
+                <p className="label text-base text-dark-pink">{errors.password.message}</p>
               )}
-            </span>
+            </div>
           </div>
         </div>
-        <label className="label">
-          <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
-        </label>
-      </div>
-      <Button
-        click={handleSubmit}
-        disabled={!email || !password ? true : false}
-        addStyle="btn-secondary h-16 w-40"
-      >
-        ログイン
-      </Button>
+        <Button
+          btnType="submit"
+          disabled={!dirtyFields.email || !dirtyFields.password}
+          addStyle="btn-secondary h-16 w-40"
+        >
+          ログイン
+        </Button>
+      </form>
       <p className="mb-6 mt-28 text-base text-dark-black">新規登録はこちら</p>
       <Link href="/signup" passHref>
-        <Button addStyle="btn-primary h-16 w-40">新規登録</Button>
+        <Button btnType="button" addStyle="btn-primary h-16 w-40">
+          新規登録
+        </Button>
       </Link>
     </div>
   )

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -5,21 +5,32 @@ import Cookies from 'js-cookie'
 import { signUp } from 'src/lib/api/auth'
 import { AuthContext } from 'src/contexts/auth'
 
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { userSchema } from 'src/validation/validation'
+
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 
 export const SignUpPage = () => {
   const router = useRouter()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
   const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
 
+  const {
+    register,
+    handleSubmit,
+    formState: { dirtyFields, errors }
+  } = useForm({
+    defaultValues: { email: '', password: '' },
+    resolver: zodResolver(userSchema)
+  })
+
   // 新規登録機能
-  const handleSubmit = async (e) => {
-    e.preventDefault()
+  const onSubmit = async (data) => {
+    const params = { email: data.email, password: data.password }
     try {
-      const res = await signUp({ email, password })
+      const res = await signUp(params)
       console.log(res)
 
       // ステータス200 OK
@@ -52,54 +63,64 @@ export const SignUpPage = () => {
   return (
     <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">新規登録</p>
-      <div className="form-control my-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">メールアドレス</span>
-        </label>
-        <input
-          type="text"
-          placeholder="your@email.com"
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-        />
-      </div>
-      <div className="form-control mb-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">パスワード</span>
-        </label>
-        <div className="flex items-center">
-          <div className="relative">
-            <input
-              type={isRevealPassword ? 'text' : 'password'}
-              placeholder="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              className="input input-bordered input-primary input-md w-96 border-dark-blue bg-ligth-white text-base text-dark-black"
-            />
-            <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
-              {isRevealPassword ? (
-                <FontAwesomeIcon icon={faEye} />
-              ) : (
-                <FontAwesomeIcon icon={faEyeSlash} />
+      <form
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+        className="grid place-content-center place-items-center"
+      >
+        <div className="form-control my-6 h-32 w-96">
+          <label htmlFor="email" className="label">
+            <span className="text-base text-dark-black">メールアドレス</span>
+          </label>
+          <input
+            id="email"
+            type="email"
+            {...register('email')}
+            placeholder="your@email.com"
+            className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+          />
+          {errors.email && <p className="label text-base text-dark-pink">{errors.email.message}</p>}
+        </div>
+        <div className="form-control mb-12 h-32 w-96">
+          <label htmlFor="password" className="label">
+            <span className="text-base text-dark-black">パスワード</span>
+            <span className="label-text-alt text-sm text-dark-black">6文字以上の半角英数字</span>
+          </label>
+          <div className="flex items-center">
+            <div className="relative">
+              <input
+                id="password"
+                type={isRevealPassword ? 'text' : 'password'}
+                {...register('password')}
+                placeholder="password"
+                className="input input-bordered input-primary input-md w-96 border-dark-blue bg-ligth-white text-base text-dark-black"
+              />
+              <span onClick={togglePassword} role="presentation" className="absolute right-3 top-3">
+                {isRevealPassword ? (
+                  <FontAwesomeIcon icon={faEye} />
+                ) : (
+                  <FontAwesomeIcon icon={faEyeSlash} />
+                )}
+              </span>
+              {errors.password && (
+                <p className="label text-base text-dark-pink">{errors.password.message}</p>
               )}
-            </span>
+            </div>
           </div>
         </div>
-        <label className="label">
-          <span className="text-sm text-dark-black">6文字以上の半角英数字</span>
-        </label>
-      </div>
-      <Button
-        click={handleSubmit}
-        disabled={!email || !password ? true : false}
-        addStyle="btn-primary h-16 w-40"
-      >
-        新規登録
-      </Button>
-      <p className="mb-6 mt-28 text-dark-black text-base">アカウントをお持ちの方はこちら</p>
+        <Button
+          btnType="submit"
+          disabled={!dirtyFields.email || !dirtyFields.password}
+          addStyle="btn-primary h-16 w-40"
+        >
+          新規登録
+        </Button>
+      </form>
+      <p className="mb-6 mt-28 text-base text-dark-black">アカウントをお持ちの方はこちら</p>
       <Link href="/signin" passHref>
-        <Button addStyle="btn-secondary h-16 w-40">ログイン</Button>
+        <Button btnType="button" addStyle="btn-secondary h-16 w-40">
+          ログイン
+        </Button>
       </Link>
     </div>
   )

--- a/frontend/src/components/shared/Button.jsx
+++ b/frontend/src/components/shared/Button.jsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx'
 
-export const Button = ({ addStyle, click, disabled, children }) => {
+export const Button = ({ addStyle, btnType, click, disabled, children }) => {
   return (
     <button
       className={clsx('btn rounded-[10px] text-base tracking-widest text-white', addStyle)}
+      type={btnType}
       onClick={(e) => {
         click && click(e)
       }}

--- a/frontend/src/validation/validation.js
+++ b/frontend/src/validation/validation.js
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  email: z
+    .string()
+    .nonempty('メールアドレスは必須です')
+    .email('メールアドレスの形式ではありません'),
+  password: z
+    .string()
+    .nonempty('パスワードは必須です')
+    .min(6, 'パスワードは6文字以上で入力してください')
+})


### PR DESCRIPTION
# 説明
以下のとおりログインページ(`/signin`)及び新規登録ページ(`/signup`)の入力フォームにバリデーションを追加し、メッセージを表示するようにしました。


### 修正前：
- メールアドレス及びパスワードが1文字以上入力されていれば、正しく入力されていなくてもsubmitできる状態。
- エラーの場合はsubmit後にアラートが表示されるが、メッセージからエラーの内容は不明。

### 修正後：
- 以下の状態でsubmitボタンを押した時に、バリデーションメッセージを表示し、submitしないようにしました。
- メッセージ表示後は入力の都度バリデーションチェックをするようにしました。
- メールアドレス：未入力、正規表現に合致しない
- パスワード：未入力、6文字未満


### 修正理由：
- 入力が正しくない場合にバリデーションメッセージを表示し、ユーザーの利便性を向上させるため。

## 実装概要
- React Hook Form及びZodのインストール `106c9ff`
- バリデーションスキーマを作成し、ログインページ(`/signin`)のバリデーションを追加 `864bbe6`
- 新規登録ページ(`/signup`)のバリデーションを追加 `249134c`

# スクリーンショット

- 未入力の場合

| 実装前 | 実装後 |
| ------------- | ------------- |
| <img width="336" alt="スクリーンショット 2023-08-26 13 59 53" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/d9c1c314-367d-4ce7-8e89-ebbe370dada8"> |  <img width="348" alt="スクリーンショット 2023-08-26 13 55 48" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/57178c69-99d3-4ff3-bb33-b1fa4669d5b7"> |


- 入力が正しくない場合

| 実装前 | 実装後 |
| ------------- | ------------- |
| <img width="466" alt="スクリーンショット 2023-08-26 14 00 54" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/20dbcc28-3f53-4f6e-9315-c25ad45222a7"> |  <img width="346" alt="スクリーンショット 2023-08-26 13 56 03" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/01af7725-d0e7-472d-89e0-acdeb046cc3d"> |


- 入力が正しい場合

| 実装前 | 実装後 |
| ------------- | ------------- |
| <img width="337" alt="スクリーンショット 2023-08-26 14 02 03" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/3fc44f1d-05f8-4b71-847c-65d058db3f47"> | <img width="339" alt="スクリーンショット 2023-08-26 13 56 19" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/3842b6b9-b6ef-4152-9cdd-e19af5d90299">|




# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
