### PR TITLE
お世話の記録を登録・表示するAPI及びページを作成

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -2,6 +2,11 @@ class Api::V1::CaresController < ApplicationController
   # ログイン状態の確認
   before_action :authenticate_api_v1_user!
 
+  # お世話記録 一覧
+  def index
+    cares = Care.where(chinchilla_id: params[:chinchilla_id])
+    render json: cares
+  end
   # お世話記録 作成
   def create
     care = Care.new(care_params)

--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::CaresController < ApplicationController
+  # ログイン状態の確認
+  before_action :authenticate_api_v1_user!
+
+  # お世話記録 作成
+  def create
+    care = Care.new(care_params)
+
+    if care.save!
+      # 成功した場合、ステータス201を返す
+      render json: care, status: :created
+    else
+      #エラー文を取得し、ステータス422を返す
+      render json: care.errors, status: :unprocessable_entity
+    end
+  end
+  private
+  def care_params
+    params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3, :chinchilla_id)
+  end
+end

--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -1,0 +1,5 @@
+class Care < ApplicationRecord
+  # Chinchillaモデルに従属
+  belongs_to :chinchilla
+
+end

--- a/backend/app/models/chinchilla.rb
+++ b/backend/app/models/chinchilla.rb
@@ -4,4 +4,8 @@ class Chinchilla < ApplicationRecord
 
   #アップローダーとchinchilla_imageカラムを紐づけ
   mount_uploader :chinchilla_image, ChinchillaImageUploader
+
+  # Careモデルと関連付け
+  has_one :care
+
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -19,6 +19,10 @@ Rails.application.routes.draw do
       put '/chinchillas/:id', to: 'chinchillas#update'
       # チンチラプロフィール 削除
       delete '/chinchillas/:id', to: 'chinchillas#destroy'
+
+      # お世話記録 作成
+      post '/cares', to: 'cares#create'
+
     end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
       # チンチラプロフィール 削除
       delete '/chinchillas/:id', to: 'chinchillas#destroy'
 
+      # お世話記録 一覧
+      get '/cares', to: 'cares#index'
       # お世話記録 作成
       post '/cares', to: 'cares#create'
 

--- a/backend/db/migrate/20230826151647_create_cares.rb
+++ b/backend/db/migrate/20230826151647_create_cares.rb
@@ -1,0 +1,20 @@
+class CreateCares < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cares do |t|
+      t.date        :care_day, null: false
+      t.string      :care_food
+      t.string      :care_toilet
+      t.string      :care_bath
+      t.string      :care_play
+      t.integer     :care_weight
+      t.float       :care_temperature
+      t.integer     :care_humidity
+      t.text        :care_memo, limit:200
+      t.string      :care_image1
+      t.string      :care_image2
+      t.string      :care_image3
+      t.references  :chinchilla, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_29_151948) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_26_151647) do
+  create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.date "care_day", null: false
+    t.string "care_food"
+    t.string "care_toilet"
+    t.string "care_bath"
+    t.string "care_play"
+    t.integer "care_weight"
+    t.float "care_temperature"
+    t.integer "care_humidity"
+    t.text "care_memo", size: :tiny
+    t.string "care_image1"
+    t.string "care_image2"
+    t.string "care_image3"
+    t.bigint "chinchilla_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chinchilla_id"], name: "index_cares_on_chinchilla_id"
+  end
+
   create_table "chinchillas", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "chinchilla_name", limit: 15, null: false
     t.string "chinchilla_sex", null: false
@@ -49,5 +68,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_29_151948) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "cares", "chinchillas"
   add_foreign_key "chinchillas", "users"
 end

--- a/backend/test/controllers/api/v1/cares_controller_test.rb
+++ b/backend/test/controllers/api/v1/cares_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::CaresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/test/fixtures/cares.yml
+++ b/backend/test/fixtures/cares.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/backend/test/models/care_test.rb
+++ b/backend/test/models/care_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CareTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,0 +1,90 @@
+import { useState, useContext, useEffect } from 'react'
+import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { getAllCares } from 'src/lib/api/care'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
+import { Button } from 'src/components/shared/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faAsterisk
+} from '@fortawesome/free-solid-svg-icons'
+
+export const CareRecordCalendarPage = () => {
+  const [allChinchillas, setAllChinchillas] = useState([])
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
+  const [allCares, setAllCares] = useState([])
+
+  // 全てのチンチラのデータを取得
+  const fetch = async () => {
+    const res = await getAllChinchillas()
+    console.log(res.data)
+    setAllChinchillas(res.data)
+  }
+
+  useEffect(() => {
+    fetch()
+  }, [])
+
+  // お世話記録一覧取得機能
+  const handleFetch = async () => {
+    try {
+      const res = await getAllCares(chinchillaId)
+      console.log(res.data)
+      setAllCares(res.data)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return (
+    <div className="my-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">お世話の記録</p>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">チンチラを選択</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <select
+          value={chinchillaId}
+          onChange={(event) => setChinchillaId(event.target.value)}
+          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+        >
+          <option hidden value="">
+            選択してください
+          </option>
+          {allChinchillas.map((chinchilla) => (
+            <option key={chinchilla.id} value={chinchilla.id}>
+              {chinchilla.chinchillaName}
+            </option>
+          ))}
+        </select>
+      </div>
+      <p className="my-3">選択中のID：{chinchillaId}</p>
+      <Button btnType="submit" click={handleFetch} addStyle="btn-primary h-16 w-40">
+        お世話記録取得
+      </Button>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">お世話の日付を選択</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <select
+          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+        >
+          <option hidden value="">
+            選択してください
+          </option>
+          {allCares.map((care) => (
+            <option key={care.id}>{care.careDay}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/care-record-registration/index.jsx
+++ b/frontend/src/components/pages/care-record-registration/index.jsx
@@ -1,0 +1,348 @@
+import { useState, useContext, useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { createCare } from 'src/lib/api/care'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
+import { Button } from 'src/components/shared/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faAsterisk,
+  faFaceSmileBeam,
+  faFaceDizzy,
+  faFaceMeh,
+  faFilePen
+} from '@fortawesome/free-solid-svg-icons'
+
+export const CareRecordRegistrationPage = () => {
+  const router = useRouter()
+  const [allChinchillas, setAllChinchillas] = useState([])
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
+
+  const [careDay, setCareDay] = useState('')
+  const [careFood, setCareFood] = useState('')
+  const [careToilet, setCareToilet] = useState('')
+  const [careBath, setCareBath] = useState('')
+  const [carePlay, setCarePlay] = useState('')
+  const [careMemo, setCareMemo] = useState('')
+
+  // 全てのチンチラのデータを取得
+  const fetch = async () => {
+    const res = await getAllChinchillas()
+    console.log(res.data)
+    setAllChinchillas(res.data)
+  }
+
+  useEffect(() => {
+    fetch()
+  }, [])
+
+  // FormData形式でデータを作成
+  const createFormData = () => {
+    const formData = new FormData()
+    formData.append('care[careDay]', careDay)
+    formData.append('care[careFood]', careFood)
+    formData.append('care[careToilet]', careToilet)
+    formData.append('care[careBath]', careBath)
+    formData.append('care[carePlay]', carePlay)
+    formData.append('care[careMemo]', careMemo)
+    formData.append('care[chinchillaId]', chinchillaId)
+    return formData
+  }
+
+  // お世話記録作成機能
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const params = createFormData()
+    try {
+      const res = await createCare(params)
+      console.log(res)
+
+      // ステータス201 Created
+      if (res.status === 201) {
+        router.push('/mychinchilla')
+        console.log('お世話記録作成成功！')
+      } else {
+        alert('お世話記録作成失敗')
+      }
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
+  }
+
+  return (
+    <div className="my-40 grid place-content-center place-items-center">
+      <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">お世話の記録</p>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">チンチラを選択</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <select
+          value={chinchillaId}
+          onChange={(event) => setChinchillaId(event.target.value)}
+          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+        >
+          <option hidden value="">
+            選択してください
+          </option>
+          {allChinchillas.map((chinchilla) => (
+            <option key={chinchilla.id} value={chinchilla.id}>
+              {chinchilla.chinchillaName}
+            </option>
+          ))}
+        </select>
+      </div>
+      <p className="my-3">選択中のID：{chinchillaId}</p>
+      <div className="form-control mt-6 w-96">
+        <label className="label">
+          <span className="text-base text-dark-black">日付</span>
+          <div>
+            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+            <span className="label-text-alt text-dark-black">必須入力</span>
+          </div>
+        </label>
+        <input
+          type="date"
+          value={careDay}
+          onChange={(event) => setCareDay(event.target.value)}
+          className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+        />
+      </div>
+      <div className="my-8 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">食事</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            <input
+              id="careFoodIsGood"
+              type="radio"
+              name="careFood"
+              value="good"
+              onChange={(e) => setCareFood(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careFoodIsGood" className="label cursor-pointer">
+              {careFood === 'good' ? (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careFoodIsUsually"
+              type="radio"
+              name="careFood"
+              value="usually"
+              onChange={(e) => setCareFood(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careFoodIsUsually" className="label cursor-pointer">
+              {careFood === 'usually' ? (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careFoodIsBad"
+              type="radio"
+              name="careFood"
+              value="bad"
+              onChange={(e) => setCareFood(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careFoodIsBad" className="label cursor-pointer">
+              {careFood === 'bad' ? (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+              )}
+            </label>
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            <input
+              id="careToiletIsGood"
+              type="radio"
+              name="careToilet"
+              value="good"
+              onChange={(e) => setCareToilet(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careToiletIsGood" className="label cursor-pointer">
+              {careToilet === 'good' ? (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careToiletIsUsually"
+              type="radio"
+              name="careToilet"
+              value="usually"
+              onChange={(e) => setCareToilet(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careToiletIsUsually" className="label cursor-pointer">
+              {careToilet === 'usually' ? (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careToiletIsBad"
+              type="radio"
+              name="careToilet"
+              value="bad"
+              onChange={(e) => setCareToilet(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careToiletIsBad" className="label cursor-pointer">
+              {careToilet === 'bad' ? (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+              )}
+            </label>
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            <input
+              id="careBathIsGood"
+              type="radio"
+              name="careBath"
+              value="good"
+              onChange={(e) => setCareBath(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careBathIsGood" className="label cursor-pointer">
+              {careBath === 'good' ? (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careBathIsUsually"
+              type="radio"
+              name="careBath"
+              value="usually"
+              onChange={(e) => setCareBath(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careBathIsUsually" className="label cursor-pointer">
+              {careBath === 'usually' ? (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="careBathIsBad"
+              type="radio"
+              name="careBath"
+              value="bad"
+              onChange={(e) => setCareBath(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="careBathIsBad" className="label cursor-pointer">
+              {careBath === 'bad' ? (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+              )}
+            </label>
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            <input
+              id="carePlayIsGood"
+              type="radio"
+              name="carePlay"
+              value="good"
+              onChange={(e) => setCarePlay(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="carePlayIsGood" className="label cursor-pointer">
+              {carePlay === 'good' ? (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="carePlayIsUsually"
+              type="radio"
+              name="carePlay"
+              value="usually"
+              onChange={(e) => setCarePlay(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="carePlayIsUsually" className="label cursor-pointer">
+              {carePlay === 'usually' ? (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+              )}
+            </label>
+            <input
+              id="carePlayIsBad"
+              type="radio"
+              name="carePlay"
+              value="bad"
+              onChange={(e) => setCarePlay(e.target.value)}
+              className="hidden"
+            />
+            <label htmlFor="carePlayIsBad" className="label cursor-pointer">
+              {carePlay === 'bad' ? (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+              ) : (
+                <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+              )}
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className="form-control mb-12 mt-12 w-[500px]">
+        <label className="mx-1 my-2 flex">
+          <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
+          <span className="label-text text-base text-dark-black">メモ</span>
+        </label>
+        <textarea
+          placeholder="メモを記入してください。"
+          value={careMemo}
+          onChange={(event) => setCareMemo(event.target.value)}
+          className="w-ful textarea textarea-primary h-96 border-dark-blue bg-ligth-white text-base text-dark-black"
+        ></textarea>
+      </div>
+      <Button
+        btnType="submit"
+        click={handleSubmit}
+        disabled={
+          // 「チンチラを選択していない」または「日付を選択していない」または「お世話記録を全て選択していない」場合は登録できない
+          // 「チンチラを選択している」かつ「日付を選択している」かつ「お世話記録を何か選択している」場合のみ登録できる
+          !chinchillaId ||
+          !careDay ||
+          (!careFood && !careToilet && !careBath && !carePlay && !careMemo)
+            ? true
+            : false
+        }
+        addStyle="btn-primary h-16 w-40"
+      >
+        登録
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/lib/api/care.js
+++ b/frontend/src/lib/api/care.js
@@ -1,0 +1,17 @@
+import Cookies from 'js-cookie'
+import { client } from 'src/lib/api/client'
+
+// 機能&リクエストURL
+
+// お世話記録 作成
+export const createCare = (params) => {
+  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
+  return client.post('/cares', params, {
+    headers: {
+      'access-token': Cookies.get('_access_token'),
+      client: Cookies.get('_client'),
+      uid: Cookies.get('_uid'),
+      'content-type': 'multipart/form-data'
+    }
+  })
+}

--- a/frontend/src/lib/api/care.js
+++ b/frontend/src/lib/api/care.js
@@ -3,6 +3,17 @@ import { client } from 'src/lib/api/client'
 
 // 機能&リクエストURL
 
+// お世話記録 一覧(全部)
+export const getAllCares = (chinchillaId) => {
+  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
+  return client.get(`/cares?chinchilla_id=${chinchillaId}`, {
+    headers: {
+      'access-token': Cookies.get('_access_token'),
+      client: Cookies.get('_client'),
+      uid: Cookies.get('_uid')
+    }
+  })
+}
 // お世話記録 作成
 export const createCare = (params) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return

--- a/frontend/src/pages/care-record-calendar.jsx
+++ b/frontend/src/pages/care-record-calendar.jsx
@@ -1,0 +1,10 @@
+import { CareRecordCalendarPage } from "src/components/pages/care-record-calendar";
+
+
+export default function CareRecordCalendar() {
+  return (
+    <>
+      <CareRecordCalendarPage />
+    </>
+  )
+}

--- a/frontend/src/pages/care-record-registration.jsx
+++ b/frontend/src/pages/care-record-registration.jsx
@@ -1,0 +1,9 @@
+import { CareRecordRegistrationPage } from 'src/components/pages/care-record-registration'
+
+export default function CareRecord() {
+  return (
+    <>
+      <CareRecordRegistrationPage />
+    </>
+  )
+}


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録の登録ページ(`/care-record-registration`)及びお世話の記録表示ページ(`/care-record-calendar`)を作成しました。カレンダーのUIは今後追加予定です。


### 修正前：
-

### 修正後：
- お世話の記録登録ページ(`/care-record-registration`)：チンチラ及び日付を選択した上で、食事、トイレ、砂浴び、部屋んぽ、メモのいずれかを入力し「登録」ボタンを押すと、選択したチンチラのお世話の記録が登録される。
- お世話の記録表示ページ(`/care-record-calendar`)：チンチラを選択した上で、「お世話記録取得」ボタンを押すと、選択したチンチラのお世話の記録を全件取得し、日付を選択できるようになる。

### 修正理由：
-

## 実装概要
- お世話の記録登録のAPI及びページ(`/care-record-registration`)の作成 `31b0ed6`
- お世話の記録表示のAPI及びページ(`/care-record-calendar`)の作成 `cd8b233`



# スクリーンショット
- お世話の記録登録ページ(`/care-record-registration`)

|  実装後 |
| ------------- | 
| ![スクリーンショット 2023-08-29 17 47 32](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/2cb58a20-3e63-48a2-b603-5a02dfe13a36)|

- お世話の記録表示ページ(`/care-record-calendar`)

| 取得前 | 取得後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-08-29 17 38 05](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/7eedaf55-5e7c-406f-a33f-055cade08142) | ![スクリーンショット 2023-08-29 17 37 53](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/83e4d205-5693-44d1-8c14-15de8c3e6794) |




# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
