### PR TITLE
お世話の記録を表示する機能を追加

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,9 +1,7 @@
-import { useState, useContext, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares } from 'src/lib/api/care'
-import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
-import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faAsterisk,
@@ -15,8 +13,8 @@ import {
 
 export const CareRecordCalendarPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
-  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
   const [allCares, setAllCares] = useState([])
+  const chinchillaIdRef = useRef(0)
   const careIdRef = useRef(0)
 
   // 入力内容の状態管理
@@ -37,12 +35,21 @@ export const CareRecordCalendarPage = () => {
     fetch()
   }, [])
 
-  // お世話記録一覧取得機能
-  const handleFetch = async () => {
+  // 選択したチンチラのお世話記録の一覧を取得
+  const handleGetChinchilla = async () => {
+    const chinchillaId = chinchillaIdRef.current.value
     try {
       const res = await getAllCares(chinchillaId)
       console.log(res.data)
       setAllCares(res.data)
+
+      // 別のチンチラを選択する際に、画面の表示をリセットする
+      setCareFood('')
+      setCareToilet('')
+      setCareBath('')
+      setCarePlay('')
+      setCareMemo('')
+
     } catch (err) {
       console.log(err)
     }
@@ -75,8 +82,8 @@ export const CareRecordCalendarPage = () => {
           </div>
         </label>
         <select
-          value={chinchillaId}
-          onChange={(event) => setChinchillaId(event.target.value)}
+          ref={chinchillaIdRef}
+          onChange={handleGetChinchilla}
           className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
         >
           <option hidden value="">
@@ -89,10 +96,6 @@ export const CareRecordCalendarPage = () => {
           ))}
         </select>
       </div>
-      <p className="my-3">選択中のID：{chinchillaId}</p>
-      <Button btnType="submit" click={handleFetch} addStyle="btn-primary h-16 w-40">
-        お世話記録取得
-      </Button>
       <div className="form-control mt-6 w-96">
         <label className="label">
           <span className="text-base text-dark-black">お世話の日付を選択</span>
@@ -116,7 +119,7 @@ export const CareRecordCalendarPage = () => {
           ))}
         </select>
       </div>
-      <div className="my-8 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
+      <div className="mt-12 mb-8 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
         <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
           <p className="w-24 text-center text-base text-dark-black">食事</p>
           <div className="flex grow justify-evenly text-center text-base text-dark-black">

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from 'react'
+import { useState, useContext, useEffect, useRef } from 'react'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
@@ -6,13 +6,25 @@ import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faAsterisk
+  faAsterisk,
+  faFaceSmileBeam,
+  faFaceDizzy,
+  faFaceMeh,
+  faFilePen
 } from '@fortawesome/free-solid-svg-icons'
 
 export const CareRecordCalendarPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
   const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
   const [allCares, setAllCares] = useState([])
+  const careIdRef = useRef(0)
+
+  // 入力内容の状態管理
+  const [careFood, setCareFood] = useState('')
+  const [careToilet, setCareToilet] = useState('')
+  const [careBath, setCareBath] = useState('')
+  const [carePlay, setCarePlay] = useState('')
+  const [careMemo, setCareMemo] = useState('')
 
   // 全てのチンチラのデータを取得
   const fetch = async () => {
@@ -34,6 +46,21 @@ export const CareRecordCalendarPage = () => {
     } catch (err) {
       console.log(err)
     }
+  }
+
+  // 選択した日付のお世話記録を表示
+  const handleSelectedCare = () => {
+    const careId = careIdRef.current.value
+    console.log('id:', careId)
+
+    // careIdは文字列なので、==で条件比較
+    const selectedCare = allCares.filter((care) => care.id == careId)
+    console.log('お世話記録表示', selectedCare)
+    setCareFood(selectedCare[0].careFood)
+    setCareToilet(selectedCare[0].careToilet)
+    setCareBath(selectedCare[0].careBath)
+    setCarePlay(selectedCare[0].carePlay)
+    setCareMemo(selectedCare[0].careMemo)
   }
 
   return (
@@ -75,15 +102,110 @@ export const CareRecordCalendarPage = () => {
           </div>
         </label>
         <select
+          ref={careIdRef}
+          onChange={handleSelectedCare}
           className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
         >
           <option hidden value="">
             選択してください
           </option>
           {allCares.map((care) => (
-            <option key={care.id}>{care.careDay}</option>
+            <option key={care.id} value={care.id}>
+              {care.careDay}
+            </option>
           ))}
         </select>
+      </div>
+      <div className="my-8 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">食事</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            {careFood === 'good' ? (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
+            )}
+            {careFood === 'usually' ? (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+            )}
+            {careFood === 'bad' ? (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+            )}
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            {careToilet === 'good' ? (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
+            )}
+            {careToilet === 'usually' ? (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+            )}
+            {careToilet === 'bad' ? (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+            )}
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            {careBath === 'good' ? (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
+            )}
+            {careBath === 'usually' ? (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+            )}
+            {careBath === 'bad' ? (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+            )}
+          </div>
+        </div>
+        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+          <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+          <div className="flex grow justify-evenly text-center text-base text-dark-black">
+            {carePlay === 'good' ? (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
+            )}
+            {carePlay === 'usually' ? (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+            )}
+            {carePlay === 'bad' ? (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+            ) : (
+              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="my-12">
+        <div className="mx-1 my-2 flex">
+          <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
+          <p className=" text-left text-base text-dark-black">メモ</p>
+        </div>
+        <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
+          <p className="whitespace-pre-wrap text-left text-base text-dark-black">{careMemo}</p>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録表示ページ(`/care-record-calendar`)で、選択した日付のお世話の記録を表示できるようにしました。

### 修正前：
- チンチラを選択後に「お世話記録取得」ボタンを押すと、お世話の日付を選択できるようになる。

### 修正後：
- チンチラを選択すると、お世話の日付を選択できるようになる。
- お世話の日付を選択すると、登録された当該日のお世話の記録が表示される。


### 修正理由：
- 不要な操作を減らし、利便性を向上させるため。

## 実装概要
- チンチラ及びお世話の日付を選択後に、お世話の記録を表示する機能を追加 `5ea9909`
- チンチラを選択した際に、お世話の記録を全て取得するよう修正`1014af5`



# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-09-06 21 21 32](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/a96364e5-afaa-4fb5-b9b6-5e6f229cd66a) |  ![スクリーンショット 2023-09-06 21 17 24](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/c92a34cd-1ccf-46ae-9f93-eb588b6bd092) |

# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
