### PR TITLE
お世話の記録を削除する機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::CaresController < ApplicationController
     cares = Care.where(chinchilla_id: params[:chinchilla_id])
     render json: cares
   end
+
   # お世話記録 作成
   def create
     care = Care.new(care_params)
@@ -19,6 +20,13 @@ class Api::V1::CaresController < ApplicationController
       render json: care.errors, status: :unprocessable_entity
     end
   end
+
+  # お世話記録 削除
+  def destroy
+    care = Care.find(params[:id])
+    care.destroy
+  end
+
   private
   def care_params
     params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3, :chinchilla_id)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
       get '/cares', to: 'cares#index'
       # お世話記録 作成
       post '/cares', to: 'cares#create'
+      # お世話記録 削除
+      delete '/cares/:id', to: 'cares#destroy'
 
     end
   end

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
-import { getAllCares } from 'src/lib/api/care'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -13,9 +13,9 @@ import {
 
 export const CareRecordCalendarPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
   const [allCares, setAllCares] = useState([])
-  const chinchillaIdRef = useRef(0)
-  const careIdRef = useRef(0)
+  const [careId, setCareId] = useState(0)
 
   // 入力内容の状態管理
   const [careFood, setCareFood] = useState('')
@@ -36,10 +36,12 @@ export const CareRecordCalendarPage = () => {
   }, [])
 
   // 選択したチンチラのお世話記録の一覧を取得
-  const handleGetChinchilla = async () => {
-    const chinchillaId = chinchillaIdRef.current.value
+  const handleGetChinchilla = async (event) => {
+    // selectedChinchillaIdはこの関数の中だけで使うchinchillaId
+    const selectedChinchillaId = event.target.value
+    setChinchillaId(selectedChinchillaId)
     try {
-      const res = await getAllCares(chinchillaId)
+      const res = await getAllCares(selectedChinchillaId)
       console.log(res.data)
       setAllCares(res.data)
 
@@ -49,19 +51,21 @@ export const CareRecordCalendarPage = () => {
       setCareBath('')
       setCarePlay('')
       setCareMemo('')
-
     } catch (err) {
       console.log(err)
+      alert('エラーです')
     }
   }
 
   // 選択した日付のお世話記録を表示
-  const handleSelectedCare = () => {
-    const careId = careIdRef.current.value
-    console.log('id:', careId)
+  const handleSelectedCare = (event) => {
+    // selectedCareIDはこの関数の中だけで使うCareId
+    const selectedCareId = event.target.value
+    setCareId(selectedCareId)
 
     // careIdは文字列なので、==で条件比較
-    const selectedCare = allCares.filter((care) => care.id == careId)
+    const selectedCare = allCares.filter((care) => care.id == selectedCareId)
+
     console.log('お世話記録表示', selectedCare)
     setCareFood(selectedCare[0].careFood)
     setCareToilet(selectedCare[0].careToilet)
@@ -82,8 +86,10 @@ export const CareRecordCalendarPage = () => {
           </div>
         </label>
         <select
-          ref={chinchillaIdRef}
-          onChange={handleGetChinchilla}
+          value={chinchillaId}
+          onChange={(e) => {
+            handleGetChinchilla(e)
+          }}
           className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
         >
           <option hidden value="">
@@ -105,8 +111,10 @@ export const CareRecordCalendarPage = () => {
           </div>
         </label>
         <select
-          ref={careIdRef}
-          onChange={handleSelectedCare}
+          value={careId}
+          onChange={(e) => {
+            handleSelectedCare(e)
+          }}
           className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
         >
           <option hidden value="">
@@ -119,7 +127,7 @@ export const CareRecordCalendarPage = () => {
           ))}
         </select>
       </div>
-      <div className="mt-12 mb-8 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
+      <div className="mb-8 mt-12 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
         <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
           <p className="w-24 text-center text-base text-dark-black">食事</p>
           <div className="flex grow justify-evenly text-center text-base text-dark-black">

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -69,7 +69,7 @@ export const CareRecordCalendarPage = () => {
     // careIdは文字列なので、==で条件比較
     const selectedCare = allCares.filter((care) => care.id == selectedCareId)
 
-    console.log('お世話記録表示', selectedCare)
+    console.log(selectedCare)
     setCareFood(selectedCare[0].careFood)
     setCareToilet(selectedCare[0].careToilet)
     setCareBath(selectedCare[0].careBath)

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -88,7 +88,9 @@ export const CareRecordCalendarPage = () => {
       const res = await deleteCare(careId)
       console.log(res)
 
-      // 削除後、選択中のチンチラ以外の画面の表示をリセットする
+      // 削除後、画面の表示をリセットする
+      setChinchillaId(0)
+      setAllCares([])
       setCareId(0)
       setCareFood('')
       setCareToilet('')

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -79,6 +79,10 @@ export const CareRecordCalendarPage = () => {
 
   // お世話記録を削除
   const handleDelete = async (e) => {
+    if (!careId) {
+      alert('お世話を選択してください')
+      return
+    }
     e.preventDefault()
     try {
       const res = await deleteCare(careId)

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useContext } from 'react'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { getAllCares, deleteCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faAsterisk,
@@ -72,6 +74,26 @@ export const CareRecordCalendarPage = () => {
     setCareBath(selectedCare[0].careBath)
     setCarePlay(selectedCare[0].carePlay)
     setCareMemo(selectedCare[0].careMemo)
+  }
+
+  // お世話記録を削除
+  const handleDelete = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await deleteCare(careId)
+      console.log(res)
+
+      // 削除後、選択中のチンチラ以外の画面の表示をリセットする
+      setCareId(0)
+      setCareFood('')
+      setCareToilet('')
+      setCareBath('')
+      setCarePlay('')
+      setCareMemo('')
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
   }
 
   return (
@@ -218,6 +240,9 @@ export const CareRecordCalendarPage = () => {
           <p className="whitespace-pre-wrap text-left text-base text-dark-black">{careMemo}</p>
         </div>
       </div>
+      <Button btnType="submit" click={handleDelete} addStyle="btn-secondary h-16 w-40">
+        削除
+      </Button>
     </div>
   )
 }

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -48,6 +48,7 @@ export const CareRecordCalendarPage = () => {
       setAllCares(res.data)
 
       // 別のチンチラを選択する際に、画面の表示をリセットする
+      setCareId(0)
       setCareFood('')
       setCareToilet('')
       setCareBath('')

--- a/frontend/src/lib/api/care.js
+++ b/frontend/src/lib/api/care.js
@@ -27,3 +27,15 @@ export const createCare = (params) => {
     }
   })
 }
+
+// お世話記録 削除
+export const deleteCare = (careId) => {
+  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
+  return client.delete(`/cares/${careId}`, {
+    headers: {
+      'access-token': Cookies.get('_access_token'),
+      client: Cookies.get('_client'),
+      uid: Cookies.get('_uid')
+    }
+  })
+}

--- a/frontend/src/lib/api/care.js
+++ b/frontend/src/lib/api/care.js
@@ -4,9 +4,9 @@ import { client } from 'src/lib/api/client'
 // 機能&リクエストURL
 
 // お世話記録 一覧(全部)
-export const getAllCares = (chinchillaId) => {
+export const getAllCares = (selectedChinchillaId) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.get(`/cares?chinchilla_id=${chinchillaId}`, {
+  return client.get(`/cares?chinchilla_id=${selectedChinchillaId}`, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),
@@ -14,6 +14,7 @@ export const getAllCares = (chinchillaId) => {
     }
   })
 }
+
 // お世話記録 作成
 export const createCare = (params) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録表示ページ(`/care-record-calendar`)で、選択した日付のお世話の記録を削除できるようにしました。


### 修正前：
-

### 修正後：
-  お世話の記録を削除したいチンチラ及び日付を選択後、「削除ボタン」を押すと、お世話の記録が削除される。

### 修正理由：
-

## 実装概要
- お世話記録を削除するAPIの作成 `9d310ef`
- お世話記録を削除する機能を作成 `c52f8cc`
- 削除機能に関するバグの修正・アラート追加等 `e6dc53f` `2fc4b38` `be302d3` `2efda92` `b468a1e`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| <img width="304" alt="スクリーンショット 2023-09-08 14 29 44" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/684510ab-5353-4245-b047-4fede14a1a99"> |  <img width="303" alt="スクリーンショット 2023-09-08 14 28 49" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/ffead498-d4f5-47b7-9d57-aab5b2cfb3f6"> |

# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
