### PR TITLE
お世話の記録を更新する機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -21,6 +21,18 @@ class Api::V1::CaresController < ApplicationController
     end
   end
 
+  # お世話記録 更新
+  def update
+    care = Care.find(params[:id])
+    if care = care.update!(care_params)
+      # 成功した場合、ステータス204を返す
+      render json: care,status: :no_content
+    else
+      #エラー文を取得し、ステータス422を返す
+      render json: care.errors, status: :unprocessable_entity
+    end
+  end
+
   # お世話記録 削除
   def destroy
     care = Care.find(params[:id])

--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -41,6 +41,6 @@ class Api::V1::CaresController < ApplicationController
 
   private
   def care_params
-    params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3, :chinchilla_id)
+    params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3)
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
       get '/cares', to: 'cares#index'
       # お世話記録 作成
       post '/cares', to: 'cares#create'
+      # お世話記録 更新
+      put '/cares/:id', to: 'cares#update'
       # お世話記録 削除
       delete '/cares/:id', to: 'cares#destroy'
 

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext } from 'react'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
-import { getAllCares, deleteCare } from 'src/lib/api/care'
+import { getAllCares, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { Button } from 'src/components/shared/Button'
@@ -15,9 +15,14 @@ import {
 
 export const CareRecordCalendarPage = () => {
   const [allChinchillas, setAllChinchillas] = useState([])
-  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
   const [allCares, setAllCares] = useState([])
   const [careId, setCareId] = useState(0)
+
+  //選択中のチンチラの状態管理（グローバル）
+  const { chinchillaId, setChinchillaId } = useContext(SelectedChinchillaIdContext)
+
+  // 編集モードの状態管理
+  const [isEditing, setIsEditing] = useState(false)
 
   // 入力内容の状態管理
   const [careFood, setCareFood] = useState('')
@@ -103,153 +108,522 @@ export const CareRecordCalendarPage = () => {
     }
   }
 
+  // 編集モードを解除した際に、もう一度お世話を表示
+  const handleReset = () => {
+    // careIdは文字列なので、==で条件比較
+    const resetedCare = allCares.filter((care) => care.id == careId)
+
+    console.log(resetedCare)
+    setCareFood(resetedCare[0].careFood)
+    setCareToilet(resetedCare[0].careToilet)
+    setCareBath(resetedCare[0].careBath)
+    setCarePlay(resetedCare[0].carePlay)
+    setCareMemo(resetedCare[0].careMemo)
+  }
+
+  // FormData形式でデータを作成
+  const createFormData = () => {
+    const formData = new FormData()
+    formData.append('care[careFood]', careFood)
+    formData.append('care[careToilet]', careToilet)
+    formData.append('care[careBath]', careBath)
+    formData.append('care[carePlay]', carePlay)
+    formData.append('care[careMemo]', careMemo)
+    return formData
+  }
+
+  // 編集内容を保存
+  const handleSave = async (event) => {
+    event.preventDefault()
+    const params = createFormData()
+    try {
+      const updateCareRes = await updateCare({
+        careId,
+        params
+      })
+      const getAllCaresRes = await getAllCares(chinchillaId)
+      console.log(updateCareRes)
+      console.log(getAllCaresRes.data)
+      setAllCares(getAllCaresRes.data)
+
+      // ステータス204 no_content
+      if (updateCareRes.status === 204) {
+        setIsEditing(false)
+        console.log('お世話記録更新成功！')
+      } else {
+        alert('お世話記録更新失敗')
+      }
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
+  }
+
   return (
     <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">お世話の記録</p>
-      <div className="form-control mt-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">チンチラを選択</span>
+      {isEditing ? (
+        <>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">選択中のチンチラ</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <select
+              value={chinchillaId}
+              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+              disabled
+            >
+              <option hidden value="">
+                選択してください
+              </option>
+              {allChinchillas.map((chinchilla) => (
+                <option key={chinchilla.id} value={chinchilla.id}>
+                  {chinchilla.chinchillaName}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">お世話の日付を選択</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <select
+              value={careId}
+              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+              disabled
+            >
+              <option hidden value="">
+                選択してください
+              </option>
+              {allCares.map((care) => (
+                <option key={care.id} value={care.id}>
+                  {care.careDay}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="mb-8 mt-12 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">食事</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                <input
+                  id="careFoodIsGood"
+                  type="radio"
+                  name="careFood"
+                  value="good"
+                  onChange={(e) => setCareFood(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careFoodIsGood" className="label cursor-pointer">
+                  {careFood === 'good' ? (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careFoodIsUsually"
+                  type="radio"
+                  name="careFood"
+                  value="usually"
+                  onChange={(e) => setCareFood(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careFoodIsUsually" className="label cursor-pointer">
+                  {careFood === 'usually' ? (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careFoodIsBad"
+                  type="radio"
+                  name="careFood"
+                  value="bad"
+                  onChange={(e) => setCareFood(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careFoodIsBad" className="label cursor-pointer">
+                  {careFood === 'bad' ? (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+                  )}
+                </label>
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                <input
+                  id="careToiletIsGood"
+                  type="radio"
+                  name="careToilet"
+                  value="good"
+                  onChange={(e) => setCareToilet(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careToiletIsGood" className="label cursor-pointer">
+                  {careToilet === 'good' ? (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careToiletIsUsually"
+                  type="radio"
+                  name="careToilet"
+                  value="usually"
+                  onChange={(e) => setCareToilet(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careToiletIsUsually" className="label cursor-pointer">
+                  {careToilet === 'usually' ? (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careToiletIsBad"
+                  type="radio"
+                  name="careToilet"
+                  value="bad"
+                  onChange={(e) => setCareToilet(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careToiletIsBad" className="label cursor-pointer">
+                  {careToilet === 'bad' ? (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+                  )}
+                </label>
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                <input
+                  id="careBathIsGood"
+                  type="radio"
+                  name="careBath"
+                  value="good"
+                  onChange={(e) => setCareBath(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careBathIsGood" className="label cursor-pointer">
+                  {careBath === 'good' ? (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careBathIsUsually"
+                  type="radio"
+                  name="careBath"
+                  value="usually"
+                  onChange={(e) => setCareBath(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careBathIsUsually" className="label cursor-pointer">
+                  {careBath === 'usually' ? (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="careBathIsBad"
+                  type="radio"
+                  name="careBath"
+                  value="bad"
+                  onChange={(e) => setCareBath(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="careBathIsBad" className="label cursor-pointer">
+                  {careBath === 'bad' ? (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+                  )}
+                </label>
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                <input
+                  id="carePlayIsGood"
+                  type="radio"
+                  name="carePlay"
+                  value="good"
+                  onChange={(e) => setCarePlay(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="carePlayIsGood" className="label cursor-pointer">
+                  {carePlay === 'good' ? (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="carePlayIsUsually"
+                  type="radio"
+                  name="carePlay"
+                  value="usually"
+                  onChange={(e) => setCarePlay(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="carePlayIsUsually" className="label cursor-pointer">
+                  {carePlay === 'usually' ? (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
+                  )}
+                </label>
+                <input
+                  id="carePlayIsBad"
+                  type="radio"
+                  name="carePlay"
+                  value="bad"
+                  onChange={(e) => setCarePlay(e.target.value)}
+                  className="hidden"
+                />
+                <label htmlFor="carePlayIsBad" className="label cursor-pointer">
+                  {carePlay === 'bad' ? (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
+                  ) : (
+                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
+                  )}
+                </label>
+              </div>
+            </div>
+          </div>
+          <div className="form-control mb-12 mt-12 w-[500px]">
+            <label className="mx-1 my-2 flex">
+              <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
+              <span className="label-text text-base text-dark-black">メモ</span>
+            </label>
+            <textarea
+              placeholder="メモを記入してください。"
+              value={careMemo}
+              onChange={(event) => setCareMemo(event.target.value)}
+              className="w-ful textarea textarea-primary h-96 border-dark-blue bg-ligth-white text-base text-dark-black"
+            ></textarea>
+          </div>
           <div>
-            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-            <span className="label-text-alt text-dark-black">必須入力</span>
+            <Button btnType="submit" click={handleSave} addStyle="btn-primary mr-24 h-16 w-40">
+              保存
+            </Button>
+            <Button
+              btnType="button"
+              click={() => {
+                setIsEditing(false)
+                handleReset()
+              }}
+              addStyle="btn-secondary h-16 w-40"
+            >
+              戻る
+            </Button>
           </div>
-        </label>
-        <select
-          value={chinchillaId}
-          onChange={(e) => {
-            handleGetChinchilla(e)
-          }}
-          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-        >
-          <option hidden value="">
-            選択してください
-          </option>
-          {allChinchillas.map((chinchilla) => (
-            <option key={chinchilla.id} value={chinchilla.id}>
-              {chinchilla.chinchillaName}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div className="form-control mt-6 w-96">
-        <label className="label">
-          <span className="text-base text-dark-black">お世話の日付を選択</span>
+        </>
+      ) : (
+        <>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">チンチラを選択</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <select
+              value={chinchillaId}
+              onChange={(e) => {
+                handleGetChinchilla(e)
+              }}
+              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+            >
+              <option hidden value="">
+                選択してください
+              </option>
+              {allChinchillas.map((chinchilla) => (
+                <option key={chinchilla.id} value={chinchilla.id}>
+                  {chinchilla.chinchillaName}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="form-control mt-6 w-96">
+            <label className="label">
+              <span className="text-base text-dark-black">お世話の日付を選択</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">必須入力</span>
+              </div>
+            </label>
+            <select
+              value={careId}
+              onChange={(e) => {
+                handleSelectedCare(e)
+              }}
+              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+            >
+              <option hidden value="">
+                選択してください
+              </option>
+              {allCares.map((care) => (
+                <option key={care.id} value={care.id}>
+                  {care.careDay}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="mb-8 mt-12 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">食事</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                {careFood === 'good' ? (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-dark-blue"
+                  />
+                ) : (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-light-black"
+                  />
+                )}
+                {careFood === 'usually' ? (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+                )}
+                {careFood === 'bad' ? (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+                )}
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                {careToilet === 'good' ? (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-dark-blue"
+                  />
+                ) : (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-light-black"
+                  />
+                )}
+                {careToilet === 'usually' ? (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+                )}
+                {careToilet === 'bad' ? (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+                )}
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                {careBath === 'good' ? (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-dark-blue"
+                  />
+                ) : (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-light-black"
+                  />
+                )}
+                {careBath === 'usually' ? (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+                )}
+                {careBath === 'bad' ? (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+                )}
+              </div>
+            </div>
+            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+              <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+              <div className="flex grow justify-evenly text-center text-base text-dark-black">
+                {carePlay === 'good' ? (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-dark-blue"
+                  />
+                ) : (
+                  <FontAwesomeIcon
+                    icon={faFaceSmileBeam}
+                    className="label text-2xl text-light-black"
+                  />
+                )}
+                {carePlay === 'usually' ? (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
+                )}
+                {carePlay === 'bad' ? (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
+                ) : (
+                  <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="my-12">
+            <div className="mx-1 my-2 flex">
+              <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
+              <p className=" text-left text-base text-dark-black">メモ</p>
+            </div>
+            <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
+              <p className="whitespace-pre-wrap text-left text-base text-dark-black">{careMemo}</p>
+            </div>
+          </div>
           <div>
-            <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-            <span className="label-text-alt text-dark-black">必須入力</span>
+            <Button
+              btnType="button"
+              click={() => {
+                setIsEditing(true)
+              }}
+              disabled={!chinchillaId || !careId ? true : false}
+              addStyle="btn-primary mr-24 h-16 w-40"
+            >
+              編集
+            </Button>
+            <Button btnType="submit" click={handleDelete} addStyle="btn-secondary h-16 w-40">
+              削除
+            </Button>
           </div>
-        </label>
-        <select
-          value={careId}
-          onChange={(e) => {
-            handleSelectedCare(e)
-          }}
-          className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-        >
-          <option hidden value="">
-            選択してください
-          </option>
-          {allCares.map((care) => (
-            <option key={care.id} value={care.id}>
-              {care.careDay}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div className="mb-8 mt-12 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
-        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-          <p className="w-24 text-center text-base text-dark-black">食事</p>
-          <div className="flex grow justify-evenly text-center text-base text-dark-black">
-            {careFood === 'good' ? (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
-            )}
-            {careFood === 'usually' ? (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
-            )}
-            {careFood === 'bad' ? (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
-            )}
-          </div>
-        </div>
-        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-          <p className="w-24 text-center text-base text-dark-black">トイレ</p>
-          <div className="flex grow justify-evenly text-center text-base text-dark-black">
-            {careToilet === 'good' ? (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
-            )}
-            {careToilet === 'usually' ? (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
-            )}
-            {careToilet === 'bad' ? (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
-            )}
-          </div>
-        </div>
-        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-          <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
-          <div className="flex grow justify-evenly text-center text-base text-dark-black">
-            {careBath === 'good' ? (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
-            )}
-            {careBath === 'usually' ? (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
-            )}
-            {careBath === 'bad' ? (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
-            )}
-          </div>
-        </div>
-        <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-          <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
-          <div className="flex grow justify-evenly text-center text-base text-dark-black">
-            {carePlay === 'good' ? (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-dark-blue" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceSmileBeam} className="label text-2xl text-light-black" />
-            )}
-            {carePlay === 'usually' ? (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-dark-black" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceMeh} className="label text-2xl text-light-black" />
-            )}
-            {carePlay === 'bad' ? (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-dark-pink" />
-            ) : (
-              <FontAwesomeIcon icon={faFaceDizzy} className="label text-2xl text-light-black" />
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="my-12">
-        <div className="mx-1 my-2 flex">
-          <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
-          <p className=" text-left text-base text-dark-black">メモ</p>
-        </div>
-        <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
-          <p className="whitespace-pre-wrap text-left text-base text-dark-black">{careMemo}</p>
-        </div>
-      </div>
-      <Button btnType="submit" click={handleDelete} addStyle="btn-secondary h-16 w-40">
-        削除
-      </Button>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/lib/api/care.js
+++ b/frontend/src/lib/api/care.js
@@ -28,6 +28,19 @@ export const createCare = (params) => {
   })
 }
 
+// お世話記録更新
+export const updateCare = ({ careId, params }) => {
+  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
+  return client.put(`/cares/${careId}`, params, {
+    headers: {
+      'access-token': Cookies.get('_access_token'),
+      client: Cookies.get('_client'),
+      uid: Cookies.get('_uid'),
+      'content-type': 'multipart/form-data'
+    }
+  })
+}
+
 // お世話記録 削除
 export const deleteCare = (careId) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録表示ページ(`/care-record-calendar`)で、選択した日付のお世話の記録を更新できるようにしました。


### 修正前：
-

### 修正後：
-  お世話の記録を更新したいチンチラ及び日付を選択後、「編集ボタン」を押すと、編集モードに切り替わる。
- 編集モードでお世話の記録を編集し、「保存」ボタンを押すと、選択した日付のお世話の記録を更新する。

### 修正理由：
-

## 実装概要
- お世話の記録を更新するAPIの作成 `3ae614f`
- ストロングパラメータの修正 `d4a9235`
- お世話の記録を更新するページの作成 `f3f2aa4`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| <img width="292" alt="スクリーンショット 2023-09-14 0 07 46" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/8e6158bd-c530-46bc-819d-7a755c9af882"> | <img width="310" alt="スクリーンショット 2023-09-14 0 08 58" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/b838c8de-1585-4409-9304-31745850ef86">  |

| 表示モード | 編集モード |
| ------------- | ------------- |
| <img width="310" alt="スクリーンショット 2023-09-14 0 08 58" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/b838c8de-1585-4409-9304-31745850ef86"> |  <img width="302" alt="スクリーンショット 2023-09-14 0 10 24" src="https://github.com/ponchoay/chinchilla-web-app/assets/129176088/968a5d69-a5da-460c-8a35-b56f1a9cfac2"> |




# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
