### PR TITLE
お世話記録表示・登録ページに遷移するアイコン・ボタンを追加

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from 'react'
+import Link from 'next/link'
 import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
@@ -10,7 +11,8 @@ import {
   faFaceSmileBeam,
   faFaceDizzy,
   faFaceMeh,
-  faFilePen
+  faFilePen,
+  faPlus
 } from '@fortawesome/free-solid-svg-icons'
 
 export const CareRecordCalendarPage = () => {
@@ -627,6 +629,15 @@ export const CareRecordCalendarPage = () => {
               削除
             </Button>
           </div>
+          <Link href="/care-record-registration" passHref>
+            <button
+              type="button"
+              className="btn btn-secondary fixed bottom-32 right-40 z-10 grid h-[80px] w-[80px] place-content-center place-items-center rounded-[50%] bg-light-pink"
+            >
+              <FontAwesomeIcon icon={faPlus} className="absolute top-3 text-4xl text-white" />
+              <p className="absolute bottom-3 text-sm text-white">登録</p>
+            </button>
+          </Link>
         </>
       )}
     </div>

--- a/frontend/src/components/pages/care-record-registration/index.jsx
+++ b/frontend/src/components/pages/care-record-registration/index.jsx
@@ -98,7 +98,6 @@ export const CareRecordRegistrationPage = () => {
           ))}
         </select>
       </div>
-      <p className="my-3">選択中のID：{chinchillaId}</p>
       <div className="form-control mt-6 w-96">
         <label htmlFor="careDay" className="label">
           <span className="text-base text-dark-black">日付</span>
@@ -115,7 +114,7 @@ export const CareRecordRegistrationPage = () => {
           className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
         />
       </div>
-      <div className="my-8 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
+      <div className="mb-8 mt-12 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
         <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
           <p className="w-24 text-center text-base text-dark-black">食事</p>
           <div className="flex grow justify-evenly text-center text-base text-dark-black">

--- a/frontend/src/components/shared/Footer.jsx
+++ b/frontend/src/components/shared/Footer.jsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faHouse } from '@fortawesome/free-solid-svg-icons'
+import { faCalendarDays, faHouse } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
 import { AuthContext } from 'src/contexts/auth'
 
@@ -11,9 +11,14 @@ export const Footer = () => {
     <footer className="fixed bottom-0 z-10 h-16 w-full bg-dark-blue">
       <div className="mx-auto flex h-full max-w-screen-lg place-content-evenly items-center">
         {isSignedIn && currentUser ? (
-          <Link href="/mychinchilla">
-            <FontAwesomeIcon icon={faHouse} className="text-4xl text-ligth-white" />
-          </Link>
+          <div>
+            <Link href="/mychinchilla">
+              <FontAwesomeIcon icon={faHouse} className="mx-12 text-4xl text-ligth-white" />
+            </Link>
+            <Link href="/care-record-calendar">
+              <FontAwesomeIcon icon={faCalendarDays} className="mx-12 text-4xl text-ligth-white" />
+            </Link>
+          </div>
         ) : (
           <></>
         )}


### PR DESCRIPTION
# 説明
以下のとおりお世話記録表示ページ(`/care-record-calendar`)及びお世話記録登録ページ(`/care-record-registration`)に遷移するアイコン・ボタンをそれぞれ追加しました。


### 修正前：
- どのページにもリンクしておらず、独立している。

### 修正後：
- お世話記録表示ページ(`/care-record-calendar`)に遷移するアイコンをフッターに追加しました。
- お世話記録登録ページ(`/care-record-registration`)に遷移するボタンをお世話記録表示ページ(`/care-record-calendar`)に追加しました。

### 修正理由：
- アプリ内で最も使用する頻度の高いページであることから、フッターに配置し、利便性を向上させるため。

## 実装概要
- お世話記録表示ページ(`/care-record-calendar`)に遷移するアイコンをフッターに追加 `d8eeb3f`
- お世話記録登録ページ(`/care-record-registration`)のデザイン修正 `28cfbd3`
- お世話記録登録ページ(`/care-record-registration`)に遷移するボタンをお世話記録表示ページ(`/care-record-calendar`)に追加 `6cc231e`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-09-16 0 16 26](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/be1a65f8-2d62-46da-b7ee-9bd0d465ac9b) |  ![スクリーンショット 2023-09-16 0 16 06](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/9a142eba-c687-433c-b36f-c2e2a2a15f78) |




# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
