### PR TITLE
バックエンド側でメモの字数制約を修正・バリデーションを追加

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -41,6 +41,6 @@ class Api::V1::CaresController < ApplicationController
 
   private
   def care_params
-    params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3)
+    params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3, :chinchilla_id)
   end
 end

--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -2,4 +2,28 @@ class Care < ApplicationRecord
   # Chinchillaモデルに従属
   belongs_to :chinchilla
 
+  # care_dayのバリデーション（未来の日付でないこと）
+  validate :care_day_cannot_be_in_the_future
+
+  def care_day_cannot_be_in_the_future
+    if care_day.present? && care_day > Date.today
+      errors.add(:care_day, "は未来の日付に設定できません")
+    end
+  end
+
+  # care_foodのバリデーション（指定の値を含むこと）
+  validates :care_food, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_toiletのバリデーション（指定の値を含むこと）
+  validates :care_toilet, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_bathのバリデーション（指定の値を含むこと）
+  validates :care_bath, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_playのバリデーション（指定の値を含むこと）
+  validates :care_play, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_memoのバリデーション（200文字以下）
+  validates :care_memo, length: { maximum:200 }
+
 end

--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -2,12 +2,23 @@ class Care < ApplicationRecord
   # Chinchillaモデルに従属
   belongs_to :chinchilla
 
-  # care_dayのバリデーション（未来の日付でないこと）
+  # care_dayのバリデーション（空でないこと,未来の日付でないこと,同じチンチラに対して重複しないこと）
+  validates :care_day, presence: true
+
   validate :care_day_cannot_be_in_the_future
+
+  validate :care_day_must_be_unique_per_chinchilla
 
   def care_day_cannot_be_in_the_future
     if care_day.present? && care_day > Date.today
       errors.add(:care_day, "は未来の日付に設定できません")
+    end
+  end
+
+  def care_day_must_be_unique_per_chinchilla
+    # 同じチンチラに対して同じcare_dayが存在するかをチェック
+    if chinchilla.present? && chinchilla.cares.where(care_day: care_day).exists?
+      errors.add(:care_day, "は同じチンチラに対して重複することはできません")
     end
   end
 

--- a/backend/app/models/chinchilla.rb
+++ b/backend/app/models/chinchilla.rb
@@ -5,8 +5,8 @@ class Chinchilla < ApplicationRecord
   #アップローダーとchinchilla_imageカラムを紐づけ
   mount_uploader :chinchilla_image, ChinchillaImageUploader
 
-  # Careモデルと関連付け
-  has_one :care
+  # Careモデルと関連付け（1対多の関係）
+  has_many :cares
 
   # chinchilla_nameのバリデーション（空でないこと,字数制限）
   validates :chinchilla_name, presence: true, length: { minimum:1, maximum:15 }

--- a/backend/app/models/chinchilla.rb
+++ b/backend/app/models/chinchilla.rb
@@ -8,4 +8,33 @@ class Chinchilla < ApplicationRecord
   # Careモデルと関連付け
   has_one :care
 
+  # chinchilla_nameのバリデーション（空でないこと,字数制限）
+  validates :chinchilla_name, presence: true, length: { minimum:1, maximum:15 }
+
+  # chinchilla_sexのバリデーション（空でないこと,指定の値を含むこと）
+  validates :chinchilla_sex, presence: true, inclusion: { in: ["オス", "メス", "不明"] }
+
+  # chinchilla_birthdayのバリデーション（未来の日付でないこと）
+  validate :chinchilla_birthday_cannot_be_in_the_future
+
+  def chinchilla_birthday_cannot_be_in_the_future
+    if chinchilla_birthday.present? && chinchilla_birthday > Date.today
+      errors.add(:chinchilla_birthday, "は未来の日付に設定できません")
+    end
+  end
+
+  # chinchilla_met_dayのバリデーション（未来の日付でないこと,chinchilla_birthdayより過去の日付でないこと）
+  validate :chinchilla_met_day_cannot_be_in_the_future_and_before_birthday
+
+  def chinchilla_met_day_cannot_be_in_the_future_and_before_birthday
+    if chinchilla_met_day.present? && chinchilla_met_day > Date.today
+      errors.add(:chinchilla_met_day, "は未来の日付に設定できません")
+    elsif chinchilla_met_day.present? && chinchilla_met_day < chinchilla_birthday
+      errors.add(:chinchilla_met_day, "は誕生日よりも過去の日付に設定してください")
+    end
+  end
+
+  # chinchilla_memoのバリデーション（200文字以下）
+  validates :chinchilla_memo, length: { maximum:200 }
+
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
-  # Chinchillaモデルと関連付け
-  has_one :chinchilla
+  # Chinchillaモデルと関連付け（1対多の関係）
+  has_many :chinchilla
 end

--- a/backend/db/migrate/20230916061645_change_chinchilla_memo_limit.rb
+++ b/backend/db/migrate/20230916061645_change_chinchilla_memo_limit.rb
@@ -1,0 +1,5 @@
+class ChangeChinchillaMemoLimit < ActiveRecord::Migration[7.0]
+  def change
+    change_column :chinchillas, :chinchilla_memo, :text, limit: 200
+  end
+end

--- a/backend/db/migrate/20230916063303_change_chinchilla_memo_string_and_limit.rb
+++ b/backend/db/migrate/20230916063303_change_chinchilla_memo_string_and_limit.rb
@@ -1,0 +1,5 @@
+class ChangeChinchillaMemoStringAndLimit < ActiveRecord::Migration[7.0]
+  def change
+    change_column :chinchillas, :chinchilla_memo, :string, limit: 200
+  end
+end

--- a/backend/db/migrate/20230916072945_change_care_memo_string_and_limit.rb
+++ b/backend/db/migrate/20230916072945_change_care_memo_string_and_limit.rb
@@ -1,0 +1,5 @@
+class ChangeCareMemoStringAndLimit < ActiveRecord::Migration[7.0]
+  def change
+    change_column :cares, :care_memo, :string, limit: 200
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_16_063303) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_16_072945) do
   create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "care_day", null: false
     t.string "care_food"
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_063303) do
     t.integer "care_weight"
     t.float "care_temperature"
     t.integer "care_humidity"
-    t.text "care_memo", size: :tiny
+    t.string "care_memo", limit: 200
     t.string "care_image1"
     t.string "care_image2"
     t.string "care_image3"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_26_151647) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_16_063303) do
   create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "care_day", null: false
     t.string "care_food"
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_26_151647) do
     t.string "chinchilla_sex", null: false
     t.date "chinchilla_birthday"
     t.date "chinchilla_met_day"
-    t.text "chinchilla_memo", size: :tiny
+    t.string "chinchilla_memo", limit: 200
     t.string "chinchilla_image"
     t.bigint "user_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
# 説明
以下のとおりバックエンド側でメモの字数制約を修正し、Chinchillaモデル及びCareモデルのバリデーションを追加しました。


### 修正前：
- DB側でchinchilla_memo及びcare_memoの字数制約が正しく設定されていない。
- Chinchillaモデル及びCareモデルについて、バリデーションが設定されていない。

### 修正後：
- DB側でchinchilla_memo及びcare_memoの字数制約を追加しました。
- Chinchillaモデル及びCareモデルについて、各種バリデーションを追加しました。

### 修正理由：
- DBの整合性を担保するため。
- 意図しない値がDBに保存されることを防ぐため。

## 実装概要
- DB側でchinchilla_memo及びcare_memoの文字数制限を追加 `39556c9` `0a581c7`
- Chinchillaモデル及びCareモデルのバリデーションを追加 `9dc32f9` `f7d2371` `a909190`
- その他コントローラー・モデルの関連付けの修正 `be04982` `85db7b1`

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
