### PR TITLE
チンチラの誕生日・お迎え日がnullであることが原因でWarningが出る問題を修正

### DIFF
--- a/backend/app/models/chinchilla.rb
+++ b/backend/app/models/chinchilla.rb
@@ -27,10 +27,12 @@ class Chinchilla < ApplicationRecord
   validate :chinchilla_met_day_cannot_be_in_the_future_and_before_birthday
 
   def chinchilla_met_day_cannot_be_in_the_future_and_before_birthday
-    if chinchilla_met_day.present? && chinchilla_met_day > Date.today
-      errors.add(:chinchilla_met_day, "は未来の日付に設定できません")
-    elsif chinchilla_met_day.present? && chinchilla_met_day < chinchilla_birthday
-      errors.add(:chinchilla_met_day, "は誕生日よりも過去の日付に設定してください")
+    if chinchilla_met_day.present?
+      if chinchilla_met_day > Date.today
+        errors.add(:chinchilla_met_day, "は未来の日付に設定できません")
+      elsif chinchilla_birthday.present? && chinchilla_met_day < chinchilla_birthday
+        errors.add(:chinchilla_met_day, "は誕生日よりも過去の日付に設定できません")
+      end
     end
   end
 

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -83,6 +83,22 @@ export const ChinchillaProfilePage = () => {
     return '/images/default.svg'
   }
 
+  // chinchillaBirthdayの値が空の場合は、DBにnullを登録
+  const handleChinchillaBirthdayChange = (event) => {
+    const newChinchillaBirthday = event.target.value
+    newChinchillaBirthday === ''
+      ? setChinchillaBirthday(null)
+      : setChinchillaBirthday(newChinchillaBirthday)
+  }
+
+  // chinchillaMetDayの値が空の場合は、DBにnullを登録
+  const handleChinchillaMetDayChange = (event) => {
+    const newChinchillaMetDay = event.target.value
+    newChinchillaMetDay === ''
+      ? setChinchillaMetDay(null)
+      : setChinchillaMetDay(newChinchillaMetDay)
+  }
+
   // FormData形式でデータを作成
   const createFormData = () => {
     const formData = new FormData()
@@ -206,8 +222,8 @@ export const ChinchillaProfilePage = () => {
             <input
               id="chinchillaBirthday"
               type="date"
-              value={chinchillaBirthday}
-              onChange={(event) => setChinchillaBirthday(event.target.value)}
+              value={chinchillaBirthday ? chinchillaBirthday : ''} // nullの場合は空を表示
+              onChange={handleChinchillaBirthdayChange}
               className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
             />
           </div>
@@ -218,8 +234,8 @@ export const ChinchillaProfilePage = () => {
             <input
               id="chinchillaMetDay"
               type="date"
-              value={chinchillaMetDay}
-              onChange={(event) => setChinchillaMetDay(event.target.value)}
+              value={chinchillaMetDay ? chinchillaMetDay : ''} // nullの場合は空を表示
+              onChange={handleChinchillaMetDayChange}
               className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
             />
           </div>


### PR DESCRIPTION
# 説明
以下のとおり、チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、誕生日・お迎え日がnullであることが原因で、編集モードにする(inputを表示させる)とWarningが出る #20 の問題を修正しました。

### 修正前：
- チンチラ登録ページ(`/chinchilla-registration`)の入力フォームでは、名前・性別は必須、画像・誕生日・お迎え日は任意となっており、誕生日・お迎え日（Date型）についても、空欄のまま登録が可能になっている。
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、**誕生日・お迎え日がnullだとWarningが出る。**

### 修正後：
- 誕生日・お迎え日について、nullの場合は入力フォームに空を表示し、入力自体は任意（nullを許容する）のままWarningを回避するよう修正しました。

### 修正理由：
- inputの値がnullであることが原因のWarningを回避するため。

## 実装概要
- 誕生日・お迎え日の入力フォーム(input)の値がnullにならないよう修正 `960495f`
- 誕生日がnullの場合でもお迎え日が登録できるようChinchillaモデルのバリデーションを修正 `a6d39f8`

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
