### PR TITLE
お世話の記録ページで体重・気温・湿度を登録・表示・更新できる機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::CaresController < ApplicationController
 
   # お世話記録 作成
   def create
-    care = Care.new(care_params)
+    care = Care.new(create_care_params)
 
     if care.save!
       # 成功した場合、ステータス201を返す
@@ -24,7 +24,7 @@ class Api::V1::CaresController < ApplicationController
   # お世話記録 更新
   def update
     care = Care.find(params[:id])
-    if care = care.update!(care_params)
+    if care = care.update!(update_care_params)
       # 成功した場合、ステータス204を返す
       render json: care,status: :no_content
     else
@@ -40,7 +40,15 @@ class Api::V1::CaresController < ApplicationController
   end
 
   private
-  def care_params
+
+  # createアクション用のストロングパラメーター
+  def create_care_params
     params.require(:care).permit(:care_day, :care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3, :chinchilla_id)
   end
+
+  # updateアクション用のストロングパラメーター
+  def update_care_params
+    params.require(:care).permit(:care_food, :care_toilet, :care_bath, :care_play, :care_weight, :care_temperature, :care_humidity, :care_memo, :care_image1, :care_image2, :care_image3)
+  end
+
 end

--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -4,10 +4,35 @@ class Care < ApplicationRecord
 
   # care_dayのバリデーション（空でないこと,未来の日付でないこと,同じチンチラに対して重複しないこと）
   validates :care_day, presence: true
-
   validate :care_day_cannot_be_in_the_future
-
   validate :care_day_must_be_unique_per_chinchilla, on: :create
+
+  # care_foodのバリデーション（指定の値を含むこと）
+  validates :care_food, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_toiletのバリデーション（指定の値を含むこと）
+  validates :care_toilet, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_bathのバリデーション（指定の値を含むこと）
+  validates :care_bath, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_playのバリデーション（指定の値を含むこと）
+  validates :care_play, inclusion: { in: ["good", "usually", "bad", ""] }
+
+  # care_weightのバリデーション（0より大きい整数であること、nullを許容すること）
+  validates :care_weight, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
+  # care_temperatureのバリデーション（0より大きく100以下の数値であること、nullを許容すること、小数第一位までであること）
+  validates :care_temperature, numericality: { greater_than: 0, less_than_or_equal_to: 100  }, allow_nil: true
+  validate :care_temperature_must_have_one_decimal_place
+
+  # care_humidityのバリデーション（0より大きく100以下の整数であること、nullを許容すること）
+  validates :care_humidity, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100 }, allow_nil: true
+
+  # care_memoのバリデーション（200文字以下）
+  validates :care_memo, length: { maximum:200 }
+
+  private
 
   def care_day_cannot_be_in_the_future
     if care_day.present? && care_day > Date.today
@@ -22,19 +47,11 @@ class Care < ApplicationRecord
     end
   end
 
-  # care_foodのバリデーション（指定の値を含むこと）
-  validates :care_food, inclusion: { in: ["good", "usually", "bad", ""] }
-
-  # care_toiletのバリデーション（指定の値を含むこと）
-  validates :care_toilet, inclusion: { in: ["good", "usually", "bad", ""] }
-
-  # care_bathのバリデーション（指定の値を含むこと）
-  validates :care_bath, inclusion: { in: ["good", "usually", "bad", ""] }
-
-  # care_playのバリデーション（指定の値を含むこと）
-  validates :care_play, inclusion: { in: ["good", "usually", "bad", ""] }
-
-  # care_memoのバリデーション（200文字以下）
-  validates :care_memo, length: { maximum:200 }
+  def care_temperature_must_have_one_decimal_place
+    # care_temperatureの小数第2位を四捨五入した値が、もとの値と一致しないかチェック
+    if care_temperature.present? && (care_temperature.round(1) != care_temperature)
+      errors.add(:care_temperature, "は小数第1位までの数値である必要があります")
+    end
+  end
 
 end

--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -19,11 +19,11 @@ class Care < ApplicationRecord
   # care_playのバリデーション（指定の値を含むこと）
   validates :care_play, inclusion: { in: ["good", "usually", "bad", ""] }
 
-  # care_weightのバリデーション（0より大きい整数であること、nullを許容すること）
-  validates :care_weight, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  # care_weightのバリデーション（0より大きく9999以下の整数であること、nullを許容すること）
+  validates :care_weight, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 9999 }, allow_nil: true
 
   # care_temperatureのバリデーション（0より大きく100以下の数値であること、nullを許容すること、小数第一位までであること）
-  validates :care_temperature, numericality: { greater_than: 0, less_than_or_equal_to: 100  }, allow_nil: true
+  validates :care_temperature, numericality: { greater_than: 0, less_than_or_equal_to: 100 }, allow_nil: true
   validate :care_temperature_must_have_one_decimal_place
 
   # care_humidityのバリデーション（0より大きく100以下の整数であること、nullを許容すること）

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-day-picker": "^8.8.2",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.4",
+        "react-number-format": "^5.3.1",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.7",
@@ -3914,6 +3915,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-number-format": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.1.tgz",
+      "integrity": "sha512-qpYcQLauIeEhCZUZY9jXZnnroOtdy3jYaS1zQ3M1Sr6r/KMOBEIGNIb7eKT19g2N1wbYgFgvDzs19hw5TrB8XQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "react-day-picker": "^8.8.2",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
+    "react-number-format": "^5.3.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -330,6 +330,7 @@ export const CareRecordCalendarPage = () => {
 
           {/* 登録モード：お世話の記録 */}
           <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
+            {/* 登録モード：食事 */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
               <p className="w-24 text-center text-base text-dark-black">食事</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -380,6 +381,7 @@ export const CareRecordCalendarPage = () => {
                 </label>
               </div>
             </div>
+            {/* 登録モード：トイレ */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
               <p className="w-24 text-center text-base text-dark-black">トイレ</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -430,6 +432,7 @@ export const CareRecordCalendarPage = () => {
                 </label>
               </div>
             </div>
+            {/* 登録モード：砂浴び */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
               <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -480,6 +483,7 @@ export const CareRecordCalendarPage = () => {
                 </label>
               </div>
             </div>
+            {/* 登録モード：部屋んぽ */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
               <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -708,6 +712,7 @@ export const CareRecordCalendarPage = () => {
 
               {/* 編集モード：お世話の記録 */}
               <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
+                {/* 編集モード：食事 */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">食事</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -764,6 +769,7 @@ export const CareRecordCalendarPage = () => {
                     </label>
                   </div>
                 </div>
+                {/* 編集モード：トイレ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">トイレ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -820,6 +826,7 @@ export const CareRecordCalendarPage = () => {
                     </label>
                   </div>
                 </div>
+                {/* 編集モード：砂浴び */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -876,6 +883,7 @@ export const CareRecordCalendarPage = () => {
                     </label>
                   </div>
                 </div>
+                {/* 編集モード：部屋んぽ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -1118,7 +1126,7 @@ export const CareRecordCalendarPage = () => {
               </div>
 
               {/* 表示モード：お世話の記録 */}
-              <div className="mt-6 h-[300px] w-[500px] rounded-xl  bg-ligth-white">
+                {/* 表示モード：食事 */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">食事</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -1157,6 +1165,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                {/* 表示モード：トイレ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">トイレ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -1195,6 +1204,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                {/* 表示モード：砂浴び */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -1233,6 +1243,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                {/* 表示モード：部屋んぽ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
                   <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
@@ -1271,6 +1282,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                {/* 表示モード：体重 */}
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">体重</p>
                   <div className="flex grow justify-evenly text-center">
@@ -1281,6 +1293,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                {/* 表示モード：気温・湿度 */}
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">気温・湿度</p>
                   <div className="flex grow justify-evenly text-center">

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -67,6 +67,7 @@ export const CareRecordCalendarPage = () => {
 
       // 別のチンチラを選択する際に、画面の表示をリセット
       setCareId(0)
+      setSelectedDate(null)
       setCareFood('')
       setCareToilet('')
       setCareBath('')

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -332,7 +332,7 @@ export const CareRecordCalendarPage = () => {
           <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
             {/* 登録モード：食事 */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-24 text-center text-base text-dark-black">食事</p>
+              <p className="w-28 text-center text-base text-dark-black">食事</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
                 <input
                   id="careFoodIsGood"
@@ -383,7 +383,7 @@ export const CareRecordCalendarPage = () => {
             </div>
             {/* 登録モード：トイレ */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+              <p className="w-28 text-center text-base text-dark-black">トイレ</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
                 <input
                   id="careToiletIsGood"
@@ -434,7 +434,7 @@ export const CareRecordCalendarPage = () => {
             </div>
             {/* 登録モード：砂浴び */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+              <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
                 <input
                   id="careBathIsGood"
@@ -485,7 +485,7 @@ export const CareRecordCalendarPage = () => {
             </div>
             {/* 登録モード：部屋んぽ */}
             <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+              <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
               <div className="flex grow justify-evenly text-center text-base text-dark-black">
                 <input
                   id="carePlayIsGood"
@@ -714,7 +714,7 @@ export const CareRecordCalendarPage = () => {
               <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
                 {/* 編集モード：食事 */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">食事</p>
+                  <p className="w-28 text-center text-base text-dark-black">食事</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     <input
                       id="careFoodIsGood"
@@ -771,7 +771,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 編集モード：トイレ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+                  <p className="w-28 text-center text-base text-dark-black">トイレ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     <input
                       id="careToiletIsGood"
@@ -828,7 +828,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 編集モード：砂浴び */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+                  <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     <input
                       id="careBathIsGood"
@@ -885,7 +885,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 編集モード：部屋んぽ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+                  <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     <input
                       id="carePlayIsGood"
@@ -1126,9 +1126,10 @@ export const CareRecordCalendarPage = () => {
               </div>
 
               {/* 表示モード：お世話の記録 */}
+              <div className="mt-6 h-[400px] w-[500px] rounded-xl  bg-ligth-white">
                 {/* 表示モード：食事 */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">食事</p>
+                  <p className="w-28 text-center text-base text-dark-black">食事</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     {careFood === 'good' ? (
                       <FontAwesomeIcon
@@ -1167,7 +1168,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 表示モード：トイレ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">トイレ</p>
+                  <p className="w-28 text-center text-base text-dark-black">トイレ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     {careToilet === 'good' ? (
                       <FontAwesomeIcon
@@ -1206,7 +1207,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 表示モード：砂浴び */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">砂浴び</p>
+                  <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     {careBath === 'good' ? (
                       <FontAwesomeIcon
@@ -1245,7 +1246,7 @@ export const CareRecordCalendarPage = () => {
                 </div>
                 {/* 表示モード：部屋んぽ */}
                 <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-24 text-center text-base text-dark-black">部屋んぽ</p>
+                  <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
                   <div className="flex grow justify-evenly text-center text-base text-dark-black">
                     {carePlay === 'good' ? (
                       <FontAwesomeIcon

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -934,6 +934,120 @@ export const CareRecordCalendarPage = () => {
                 </div>
               </div>
 
+              {/* 編集モード：体重 */}
+              <div className="form-control mt-6 w-96">
+                <label htmlFor="careWeight" className="label">
+                  <span className="text-base text-dark-black">体重（g）</span>
+                  <div>
+                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                    <span className="label-text-alt text-dark-black">半角数字</span>
+                  </div>
+                </label>
+                <NumericFormat
+                  id="careWeight"
+                  defaultValue={careWeight}
+                  onValueChange={(values) => {
+                    // 文字列としての生の値を取得
+                    const rawValue = values.value
+
+                    // 文字列を数値に変換
+                    const careWeight = parseFloat(rawValue)
+                    setCareWeight(careWeight)
+                  }}
+                  isAllowed={(values) => {
+                    const { floatValue, formattedValue } = values
+
+                    // 入力が空の場合は許容
+                    if (formattedValue === '') return true
+
+                    // 1から9999の範囲内であることを確認
+                    return floatValue >= 1 && floatValue <= 9999
+                  }}
+                  placeholder="500"
+                  thousandSeparator=","
+                  allowNegative={false}
+                  decimalScale={0}
+                  suffix={'g'}
+                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+                />
+              </div>
+
+              {/* 編集モード：気温 */}
+              <div className="form-control mt-6 w-96">
+                <label htmlFor="careTemperature" className="label">
+                  <span className="text-base text-dark-black">気温（℃）</span>
+                  <div>
+                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                    <span className="label-text-alt text-dark-black">半角数字</span>
+                  </div>
+                </label>
+                <NumericFormat
+                  id="careTemperature"
+                  defaultValue={careTemperature}
+                  onValueChange={(values) => {
+                    // 文字列としての生の値を取得
+                    const rawValue = values.value
+
+                    // 文字列を数値に変換
+                    const careTemperature = parseFloat(rawValue)
+                    setCareTemperature(careTemperature)
+                  }}
+                  isAllowed={(values) => {
+                    const { floatValue, formattedValue } = values
+
+                    // 入力が空の場合は許容
+                    if (formattedValue === '') return true
+
+                    // 1から100の範囲内であることを確認
+                    return floatValue >= 1 && floatValue <= 100
+                  }}
+                  placeholder="21.5"
+                  thousandSeparator=","
+                  allowNegative={false}
+                  decimalScale={1}
+                  suffix={'℃'}
+                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+                />
+              </div>
+
+              {/* 編集モード：湿度 */}
+              <div className="form-control mt-6 w-96">
+                <label htmlFor="careHumidity" className="label">
+                  <span className="text-base text-dark-black">湿度（%）</span>
+                  <div>
+                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                    <span className="label-text-alt text-dark-black">半角数字</span>
+                  </div>
+                </label>
+                <NumericFormat
+                  id="careHumidity"
+                  defaultValue={careHumidity}
+                  onValueChange={(values) => {
+                    // 文字列としての生の値を取得
+                    const rawValue = values.value
+
+                    // 文字列を数値に変換
+                    const careHumidity = parseFloat(rawValue)
+                    setCareHumidity(careHumidity)
+                  }}
+                  isAllowed={(values) => {
+                    const { floatValue, formattedValue } = values
+
+                    // 入力が空の場合は許容
+                    if (formattedValue === '') return true
+
+                    // 1から100の範囲内であることを確認
+                    return floatValue >= 1 && floatValue <= 100
+                  }}
+                  placeholder="40"
+                  thousandSeparator=","
+                  allowNegative={false}
+                  decimalScale={0}
+                  suffix={'%'}
+                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+                />
+              </div>
+
               {/* 編集モード：お世話のメモ */}
               <div className="form-control mb-12 mt-6 w-[500px]">
                 <label htmlFor="careMemo" className="mx-1 my-2 flex">

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -3,6 +3,8 @@ import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { NumericFormat } from 'react-number-format'
+
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -33,6 +35,9 @@ export const CareRecordCalendarPage = () => {
   const [careToilet, setCareToilet] = useState('')
   const [careBath, setCareBath] = useState('')
   const [carePlay, setCarePlay] = useState('')
+  const [careWeight, setCareWeight] = useState(null)
+  const [careTemperature, setCareTemperature] = useState(null)
+  const [careHumidity, setCareHumidity] = useState(null)
   const [careMemo, setCareMemo] = useState('')
 
   // 選択中のカレンダーの日付の状態管理
@@ -66,6 +71,9 @@ export const CareRecordCalendarPage = () => {
       setCareToilet('')
       setCareBath('')
       setCarePlay('')
+      setCareWeight(null)
+      setCareTemperature(null)
+      setCareHumidity(null)
       setCareMemo('')
     } catch (err) {
       console.log(err)
@@ -93,6 +101,9 @@ export const CareRecordCalendarPage = () => {
       setCareToilet('')
       setCareBath('')
       setCarePlay('')
+      setCareWeight(null)
+      setCareTemperature(null)
+      setCareHumidity(null)
       setCareMemo('')
       return
     }
@@ -114,6 +125,9 @@ export const CareRecordCalendarPage = () => {
       setCareToilet('')
       setCareBath('')
       setCarePlay('')
+      setCareWeight(null)
+      setCareTemperature(null)
+      setCareHumidity(null)
       setCareMemo('')
     } else {
       // お世話の記録がある場合
@@ -122,6 +136,9 @@ export const CareRecordCalendarPage = () => {
       setCareToilet(selectedCare[0].careToilet)
       setCareBath(selectedCare[0].careBath)
       setCarePlay(selectedCare[0].carePlay)
+      setCareWeight(selectedCare[0].careWeight)
+      setCareTemperature(selectedCare[0].careTemperature)
+      setCareHumidity(selectedCare[0].careHumidity)
       setCareMemo(selectedCare[0].careMemo)
     }
   }
@@ -146,6 +163,9 @@ export const CareRecordCalendarPage = () => {
       setCareToilet('')
       setCareBath('')
       setCarePlay('')
+      setCareWeight(null)
+      setCareTemperature(null)
+      setCareHumidity(null)
       setCareMemo('')
     } catch (err) {
       console.log(err)
@@ -163,6 +183,9 @@ export const CareRecordCalendarPage = () => {
     setCareToilet(resetedCare[0].careToilet)
     setCareBath(resetedCare[0].careBath)
     setCarePlay(resetedCare[0].carePlay)
+    setCareWeight(resetedCare[0].careWeight)
+    setCareTemperature(resetedCare[0].careTemperature)
+    setCareHumidity(resetedCare[0].careHumidity)
     setCareMemo(resetedCare[0].careMemo)
   }
 
@@ -174,6 +197,9 @@ export const CareRecordCalendarPage = () => {
     formData.append('care[careToilet]', careToilet)
     formData.append('care[careBath]', careBath)
     formData.append('care[carePlay]', carePlay)
+    formData.append('care[careWeight]', careWeight)
+    formData.append('care[careTemperature]', careTemperature)
+    formData.append('care[careHumidity]', careHumidity)
     formData.append('care[careMemo]', careMemo)
     formData.append('care[chinchillaId]', chinchillaId)
     return formData
@@ -203,6 +229,9 @@ export const CareRecordCalendarPage = () => {
         setCareToilet(resetedCare[0].careToilet)
         setCareBath(resetedCare[0].careBath)
         setCarePlay(resetedCare[0].carePlay)
+        setCareWeight(resetedCare[0].careWeight)
+        setCareTemperature(resetedCare[0].careTemperature)
+        setCareHumidity(resetedCare[0].careHumidity)
         setCareMemo(resetedCare[0].careMemo)
 
         console.log('お世話記録作成成功！')
@@ -222,6 +251,9 @@ export const CareRecordCalendarPage = () => {
     formData.append('care[careToilet]', careToilet)
     formData.append('care[careBath]', careBath)
     formData.append('care[carePlay]', carePlay)
+    formData.append('care[careWeight]', careWeight)
+    formData.append('care[careTemperature]', careTemperature)
+    formData.append('care[careHumidity]', careHumidity)
     formData.append('care[careMemo]', careMemo)
     return formData
   }
@@ -498,6 +530,117 @@ export const CareRecordCalendarPage = () => {
                 </label>
               </div>
             </div>
+          </div>
+
+          {/* 登録モード：体重 */}
+          <div className="form-control mt-6 w-96">
+            <label htmlFor="careWeight" className="label">
+              <span className="text-base text-dark-black">体重（g）</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">半角数字</span>
+              </div>
+            </label>
+            <NumericFormat
+              id="careWeight"
+              onValueChange={(values) => {
+                // 文字列としての生の値を取得
+                const rawValue = values.value
+
+                // 文字列を数値に変換
+                const careWeight = parseFloat(rawValue)
+                setCareWeight(careWeight)
+              }}
+              isAllowed={(values) => {
+                const { floatValue, formattedValue } = values
+
+                // 入力が空の場合は許容
+                if (formattedValue === '') return true
+
+                // 1から9999の範囲内であることを確認
+                return floatValue >= 1 && floatValue <= 9999
+              }}
+              placeholder="500"
+              thousandSeparator=","
+              allowNegative={false}
+              decimalScale={0}
+              suffix={'g'}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+            />
+          </div>
+
+          {/* 登録モード：気温 */}
+          <div className="form-control mt-6 w-96">
+            <label htmlFor="careTemperature" className="label">
+              <span className="text-base text-dark-black">気温（℃）</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">半角数字</span>
+              </div>
+            </label>
+            <NumericFormat
+              id="careTemperature"
+              onValueChange={(values) => {
+                // 文字列としての生の値を取得
+                const rawValue = values.value
+
+                // 文字列を数値に変換
+                const careTemperature = parseFloat(rawValue)
+                setCareTemperature(careTemperature)
+              }}
+              isAllowed={(values) => {
+                const { floatValue, formattedValue } = values
+
+                // 入力が空の場合は許容
+                if (formattedValue === '') return true
+
+                // 1から100の範囲内であることを確認
+                return floatValue >= 1 && floatValue <= 100
+              }}
+              placeholder="21.5"
+              thousandSeparator=","
+              allowNegative={false}
+              decimalScale={1}
+              suffix={'℃'}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+            />
+          </div>
+
+          {/* 登録モード：湿度 */}
+          <div className="form-control mt-6 w-96">
+            <label htmlFor="careHumidity" className="label">
+              <span className="text-base text-dark-black">湿度（%）</span>
+              <div>
+                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+                <span className="label-text-alt text-dark-black">半角数字</span>
+              </div>
+            </label>
+            <NumericFormat
+              id="careHumidity"
+              onValueChange={(values) => {
+                // 文字列としての生の値を取得
+                const rawValue = values.value
+
+                // 文字列を数値に変換
+                const careHumidity = parseFloat(rawValue)
+                setCareHumidity(careHumidity)
+              }}
+              isAllowed={(values) => {
+                const { floatValue, formattedValue } = values
+
+                // 入力が空の場合は許容
+                if (formattedValue === '') return true
+
+                // 1から100の範囲内であることを確認
+                return floatValue >= 1 && floatValue <= 100
+              }}
+              placeholder="40"
+              thousandSeparator=","
+              allowNegative={false}
+              decimalScale={0}
+              suffix={'%'}
+              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+            />
           </div>
 
           {/* 登録モード：お世話のメモ */}

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1157,6 +1157,31 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+                <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
+                  <p className="w-28 text-center text-base text-dark-black">体重</p>
+                  <div className="flex grow justify-evenly text-center">
+                    {careWeight ? (
+                      <p className="text-center text-base text-dark-black">{careWeight}g</p>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                </div>
+                <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
+                  <p className="w-28 text-center text-base text-dark-black">気温・湿度</p>
+                  <div className="flex grow justify-evenly text-center">
+                    {careTemperature ? (
+                      <p className="text-center text-base text-dark-black">{careTemperature}℃</p>
+                    ) : (
+                      <></>
+                    )}
+                    {careHumidity ? (
+                      <p className="text-center text-base text-dark-black">{careHumidity}%</p>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                </div>
               </div>
 
               {/* 表示モード：お世話のメモ */}


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)で体重・気温・湿度を登録・表示・更新できるようにしました。

### 修正前：
- 

### 修正後：
- 体重・気温・湿度を登録・表示・更新できるようにしました。

### 修正理由：
-

## 実装概要
- バックエンド側のバリデーション等に関する修正 `2766cc0` `ada6eda` `7802aea`
- フロントエンド側の登録・表示・更新に関する修正 `85b56e5` `0040fa0` `2decfeb` `fd91048`
- デザイン等の修正 `1e01861` `8116c4a` 

# スクリーンショット
- 登録画面

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-10-03 17 38 10](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/be2df643-8e8e-43be-9867-5bf2f3f24ea4) |  ![スクリーンショット 2023-10-03 17 33 43](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/f4c776f9-0363-4d31-a8c1-be102950e515) |

- 表示画面

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-10-03 17 39 07](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/f02b65ba-6ba2-494c-b11b-b70ddac57d64) | ![スクリーンショット 2023-10-03 17 34 45](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/7ebb5d6d-39e2-4928-bfff-e2442be6a546) |

- 編集画面

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-10-03 17 39 33](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/c91bbc50-92ea-4a73-b1c0-b47c65b543bc) | ![スクリーンショット 2023-10-03 17 35 12](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/a35830ef-6e5e-4925-a503-570792959ed2) |

# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
