### PR TITLE
お世話の記録ページの複数の修正

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/careMemoFormItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/careMemoFormItem.jsx
@@ -1,0 +1,20 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFilePen } from '@fortawesome/free-solid-svg-icons'
+
+export const CareMemoFormItem = ({ careMemo, setCareMemo }) => {
+  return (
+    <div className="form-control mb-12 mt-6 w-[500px]">
+      <label htmlFor="careMemo" className="mx-1 my-2 flex">
+        <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
+        <span className="label-text text-base text-dark-black">メモ</span>
+      </label>
+      <textarea
+        id="careMemo"
+        placeholder="メモを記入してください。"
+        value={careMemo}
+        onChange={(event) => setCareMemo(event.target.value)}
+        className="w-ful textarea textarea-primary h-96 border-dark-blue bg-ligth-white text-base text-dark-black"
+      ></textarea>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/care-record-calendar/chinchillaSelectFormItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/chinchillaSelectFormItem.jsx
@@ -1,0 +1,39 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
+
+export const ChinchillaSelectFormItem = ({
+  chinchillaId,
+  handleGetChinchilla,
+  isEditing,
+  allChinchillas
+}) => {
+  return (
+    <div className="form-control mt-6 w-96">
+      <label htmlFor="chinchillaName" className="label">
+        <span className="text-base text-dark-black">チンチラを選択</span>
+        <div>
+          <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+          <span className="label-text-alt text-dark-black">必須入力</span>
+        </div>
+      </label>
+      <select
+        id="chinchillaName"
+        value={chinchillaId}
+        onChange={(e) => {
+          handleGetChinchilla(e)
+        }}
+        className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
+        disabled={isEditing === true}
+      >
+        <option hidden value="">
+          選択してください
+        </option>
+        {allChinchillas.map((chinchilla) => (
+          <option key={chinchilla.id} value={chinchilla.id}>
+            {chinchilla.chinchillaName}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/care-record-calendar/displayRadioButtonItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/displayRadioButtonItem.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFaceSmileBeam, faFaceDizzy, faFaceMeh } from '@fortawesome/free-solid-svg-icons'
+
+export const DisplayRadioButtonItem = ({ label, item, value }) => {
+  return (
+    <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+      <p className="w-28 text-center text-base text-dark-black">{label}</p>
+      <div className="flex grow justify-evenly text-center text-base text-dark-black">
+        {['good', 'usually', 'bad'].map((status) => (
+          <React.Fragment key={`care${item}Is${status}`}>
+            {value === status ? (
+              <FontAwesomeIcon
+                icon={
+                  status === 'good'
+                    ? faFaceSmileBeam
+                    : status === 'usually'
+                    ? faFaceMeh
+                    : faFaceDizzy
+                }
+                className={`label text-2xl ${
+                  value === status
+                    ? status === 'good'
+                      ? 'text-dark-blue'
+                      : status === 'bad'
+                      ? 'text-dark-pink'
+                      : 'text-dark-black'
+                    : 'text-light-black'
+                }`}
+              />
+            ) : (
+              <FontAwesomeIcon
+                icon={
+                  status === 'good'
+                    ? faFaceSmileBeam
+                    : status === 'usually'
+                    ? faFaceMeh
+                    : faFaceDizzy
+                }
+                className="label text-2xl text-light-black"
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -3,6 +3,8 @@ import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { RadioButtonItem } from 'src/components/pages/care-record-calendar/radioButtonItem'
+
 import { NumericFormat } from 'react-number-format'
 
 import { Button } from 'src/components/shared/Button'
@@ -286,15 +288,6 @@ export const CareRecordCalendarPage = () => {
     }
   }
 
-  // ラジオボタンの削除
-  const handleRadioClick = (setter, currentValue, newValue) => {
-    if (currentValue === newValue) {
-      return setter('')
-    }
-
-    setter(newValue)
-  }
-
   return (
     <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">お世話の記録</p>
@@ -340,210 +333,15 @@ export const CareRecordCalendarPage = () => {
 
           {/* 登録モード：お世話の記録 */}
           <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
-            {/* 登録モード：食事 */}
-            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-28 text-center text-base text-dark-black">食事</p>
-              <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                <input
-                  id="careFoodIsGood"
-                  type="radio"
-                  name="careFood"
-                  value="good"
-                  onChange={(e) => setCareFood(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careFoodIsGood" className="label cursor-pointer">
-                  {careFood === 'good' ? (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careFoodIsUsually"
-                  type="radio"
-                  name="careFood"
-                  value="usually"
-                  onChange={(e) => setCareFood(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careFoodIsUsually" className="label cursor-pointer">
-                  {careFood === 'usually' ? (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careFoodIsBad"
-                  type="radio"
-                  name="careFood"
-                  value="bad"
-                  onChange={(e) => setCareFood(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careFoodIsBad" className="label cursor-pointer">
-                  {careFood === 'bad' ? (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                  )}
-                </label>
-              </div>
-            </div>
-            {/* 登録モード：トイレ */}
-            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-28 text-center text-base text-dark-black">トイレ</p>
-              <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                <input
-                  id="careToiletIsGood"
-                  type="radio"
-                  name="careToilet"
-                  value="good"
-                  onChange={(e) => setCareToilet(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careToiletIsGood" className="label cursor-pointer">
-                  {careToilet === 'good' ? (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careToiletIsUsually"
-                  type="radio"
-                  name="careToilet"
-                  value="usually"
-                  onChange={(e) => setCareToilet(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careToiletIsUsually" className="label cursor-pointer">
-                  {careToilet === 'usually' ? (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careToiletIsBad"
-                  type="radio"
-                  name="careToilet"
-                  value="bad"
-                  onChange={(e) => setCareToilet(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careToiletIsBad" className="label cursor-pointer">
-                  {careToilet === 'bad' ? (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                  )}
-                </label>
-              </div>
-            </div>
-            {/* 登録モード：砂浴び */}
-            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
-              <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                <input
-                  id="careBathIsGood"
-                  type="radio"
-                  name="careBath"
-                  value="good"
-                  onChange={(e) => setCareBath(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careBathIsGood" className="label cursor-pointer">
-                  {careBath === 'good' ? (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careBathIsUsually"
-                  type="radio"
-                  name="careBath"
-                  value="usually"
-                  onChange={(e) => setCareBath(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careBathIsUsually" className="label cursor-pointer">
-                  {careBath === 'usually' ? (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="careBathIsBad"
-                  type="radio"
-                  name="careBath"
-                  value="bad"
-                  onChange={(e) => setCareBath(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="careBathIsBad" className="label cursor-pointer">
-                  {careBath === 'bad' ? (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                  )}
-                </label>
-              </div>
-            </div>
-            {/* 登録モード：部屋んぽ */}
-            <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-              <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
-              <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                <input
-                  id="carePlayIsGood"
-                  type="radio"
-                  name="carePlay"
-                  value="good"
-                  onChange={(e) => setCarePlay(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="carePlayIsGood" className="label cursor-pointer">
-                  {carePlay === 'good' ? (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-dark-blue" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceSmileBeam} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="carePlayIsUsually"
-                  type="radio"
-                  name="carePlay"
-                  value="usually"
-                  onChange={(e) => setCarePlay(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="carePlayIsUsually" className="label cursor-pointer">
-                  {carePlay === 'usually' ? (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                  )}
-                </label>
-                <input
-                  id="carePlayIsBad"
-                  type="radio"
-                  name="carePlay"
-                  value="bad"
-                  onChange={(e) => setCarePlay(e.target.value)}
-                  className="hidden"
-                />
-                <label htmlFor="carePlayIsBad" className="label cursor-pointer">
-                  {carePlay === 'bad' ? (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                  ) : (
-                    <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                  )}
-                </label>
-              </div>
-            </div>
+            <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
+            <RadioButtonItem
+              label="トイレ"
+              item="Toilet"
+              value={careToilet}
+              setValue={setCareToilet}
+            />
+            <RadioButtonItem label="砂浴び" item="Bath" value={careBath} setValue={setCareBath} />
+            <RadioButtonItem label="部屋んぽ" item="Play" value={carePlay} setValue={setCarePlay} />
           </div>
 
           {/* 登録モード：体重 */}
@@ -711,294 +509,25 @@ export const CareRecordCalendarPage = () => {
 
               {/* 編集モード：お世話の記録 */}
               <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
-                {/* 編集モード：食事 */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">食事</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    <input
-                      id="careFoodIsGood"
-                      type="radio"
-                      name="careFood"
-                      value="good"
-                      checked={careFood === 'good'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careFoodIsGood"
-                      onClick={() => handleRadioClick(setCareFood, careFood, 'good')}
-                      className="label cursor-pointer"
-                    >
-                      {careFood === 'good' ? (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-dark-blue"
-                        />
-                      ) : (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-light-black"
-                        />
-                      )}
-                    </label>
-                    <input
-                      id="careFoodIsUsually"
-                      type="radio"
-                      name="careFood"
-                      value="usually"
-                      checked={careFood === 'usually'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careFoodIsUsually"
-                      onClick={() => handleRadioClick(setCareFood, careFood, 'usually')}
-                      className="label cursor-pointer"
-                    >
-                      {careFood === 'usually' ? (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                    <input
-                      id="careFoodIsBad"
-                      type="radio"
-                      name="careFood"
-                      value="bad"
-                      checked={careFood === 'bad'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careFoodIsBad"
-                      onClick={() => handleRadioClick(setCareFood, careFood, 'bad')}
-                      className="label cursor-pointer"
-                    >
-                      {careFood === 'bad' ? (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                  </div>
-                </div>
-                {/* 編集モード：トイレ */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">トイレ</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    <input
-                      id="careToiletIsGood"
-                      type="radio"
-                      name="careToilet"
-                      value="good"
-                      checked={careToilet === 'good'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careToiletIsGood"
-                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'good')}
-                      className="label cursor-pointer"
-                    >
-                      {careToilet === 'good' ? (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-dark-blue"
-                        />
-                      ) : (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-light-black"
-                        />
-                      )}
-                    </label>
-                    <input
-                      id="careToiletIsUsually"
-                      type="radio"
-                      name="careToilet"
-                      value="usually"
-                      checked={careToilet === 'usually'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careToiletIsUsually"
-                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'usually')}
-                      className="label cursor-pointer"
-                    >
-                      {careToilet === 'usually' ? (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                    <input
-                      id="careToiletIsBad"
-                      type="radio"
-                      name="careToilet"
-                      value="bad"
-                      checked={careToilet === 'bad'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careToiletIsBad"
-                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'bad')}
-                      className="label cursor-pointer"
-                    >
-                      {careToilet === 'bad' ? (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                  </div>
-                </div>
-                {/* 編集モード：砂浴び */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    <input
-                      id="careBathIsGood"
-                      type="radio"
-                      name="careBath"
-                      value="good"
-                      checked={careBath === 'good'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careBathIsGood"
-                      onClick={() => handleRadioClick(setCareBath, careBath, 'good')}
-                      className="label cursor-pointer"
-                    >
-                      {careBath === 'good' ? (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-dark-blue"
-                        />
-                      ) : (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-light-black"
-                        />
-                      )}
-                    </label>
-                    <input
-                      id="careBathIsUsually"
-                      type="radio"
-                      name="careBath"
-                      value="usually"
-                      checked={careBath === 'usually'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careBathIsUsually"
-                      onClick={() => handleRadioClick(setCareBath, careBath, 'usually')}
-                      className="label cursor-pointer"
-                    >
-                      {careBath === 'usually' ? (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                    <input
-                      id="careBathIsBad"
-                      type="radio"
-                      name="careBath"
-                      value="bad"
-                      checked={careBath === 'bad'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="careBathIsBad"
-                      onClick={() => handleRadioClick(setCareBath, careBath, 'bad')}
-                      className="label cursor-pointer"
-                    >
-                      {careBath === 'bad' ? (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                  </div>
-                </div>
-                {/* 編集モード：部屋んぽ */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    <input
-                      id="carePlayIsGood"
-                      type="radio"
-                      name="carePlay"
-                      value="good"
-                      checked={carePlay === 'good'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="carePlayIsGood"
-                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'good')}
-                      className="label cursor-pointer"
-                    >
-                      {carePlay === 'good' ? (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-dark-blue"
-                        />
-                      ) : (
-                        <FontAwesomeIcon
-                          icon={faFaceSmileBeam}
-                          className="text-2xl text-light-black"
-                        />
-                      )}
-                    </label>
-                    <input
-                      id="carePlayIsUsually"
-                      type="radio"
-                      name="carePlay"
-                      value="usually"
-                      checked={carePlay === 'usually'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="carePlayIsUsually"
-                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'usually')}
-                      className="label cursor-pointer"
-                    >
-                      {carePlay === 'usually' ? (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                    <input
-                      id="carePlayIsBad"
-                      type="radio"
-                      name="carePlay"
-                      value="bad"
-                      checked={carePlay === 'bad'}
-                      onChange={() => {}}
-                      className="hidden"
-                    />
-                    <label
-                      htmlFor="carePlayIsBad"
-                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'bad')}
-                      className="label cursor-pointer"
-                    >
-                      {carePlay === 'bad' ? (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
-                      ) : (
-                        <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-light-black" />
-                      )}
-                    </label>
-                  </div>
-                </div>
+                <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
+                <RadioButtonItem
+                  label="トイレ"
+                  item="Toilet"
+                  value={careToilet}
+                  setValue={setCareToilet}
+                />
+                <RadioButtonItem
+                  label="砂浴び"
+                  item="Bath"
+                  value={careBath}
+                  setValue={setCareBath}
+                />
+                <RadioButtonItem
+                  label="部屋んぽ"
+                  item="Play"
+                  value={carePlay}
+                  setValue={setCarePlay}
+                />
               </div>
 
               {/* 編集モード：体重 */}

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -3,13 +3,13 @@ import { getAllChinchillas } from 'src/lib/api/chinchilla'
 import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { ChinchillaSelectFormItem } from 'src/components/pages/care-record-calendar/chinchillaSelectFormItem'
 import { RadioButtonItem } from 'src/components/pages/care-record-calendar/radioButtonItem'
 import { NumericFormItem } from 'src/components/pages/care-record-calendar/numericFormItem'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faAsterisk,
   faFaceSmileBeam,
   faFaceDizzy,
   faFaceMeh,
@@ -300,36 +300,16 @@ export const CareRecordCalendarPage = () => {
         className="mt-6"
       />
 
+      {/* チンチラの選択 */}
+      <ChinchillaSelectFormItem
+        chinchillaId={chinchillaId}
+        handleGetChinchilla={handleGetChinchilla}
+        allChinchillas={allChinchillas}
+        isEditing={isEditing}
+      />
+
       {careId === 0 ? (
         <>
-          {/* 登録モード：チンチラの選択 */}
-          <div className="form-control mt-6 w-96">
-            <label htmlFor="chinchillaName" className="label">
-              <span className="text-base text-dark-black">チンチラを選択</span>
-              <div>
-                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                <span className="label-text-alt text-dark-black">必須入力</span>
-              </div>
-            </label>
-            <select
-              id="chinchillaName"
-              value={chinchillaId}
-              onChange={(e) => {
-                handleGetChinchilla(e)
-              }}
-              className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-            >
-              <option hidden value="">
-                選択してください
-              </option>
-              {allChinchillas.map((chinchilla) => (
-                <option key={chinchilla.id} value={chinchilla.id}>
-                  {chinchilla.chinchillaName}
-                </option>
-              ))}
-            </select>
-          </div>
-
           {/* 登録モード：お世話の記録 */}
           <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
             <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
@@ -426,32 +406,6 @@ export const CareRecordCalendarPage = () => {
         <>
           {isEditing ? (
             <>
-              {/* 編集モード：チンチラの選択 */}
-              <div className="form-control mt-6 w-96">
-                <label htmlFor="chinchillaName" className="label">
-                  <span className="text-base text-dark-black">選択中のチンチラ</span>
-                  <div>
-                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                    <span className="label-text-alt text-dark-black">必須入力</span>
-                  </div>
-                </label>
-                <select
-                  id="chinchillaName"
-                  value={chinchillaId}
-                  className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-                  disabled
-                >
-                  <option hidden value="">
-                    選択してください
-                  </option>
-                  {allChinchillas.map((chinchilla) => (
-                    <option key={chinchilla.id} value={chinchilla.id}>
-                      {chinchilla.chinchillaName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
               {/* 編集モード：お世話の記録 */}
               <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
                 <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
@@ -571,34 +525,6 @@ export const CareRecordCalendarPage = () => {
             </>
           ) : (
             <>
-              {/* 表示モード：チンチラの選択 */}
-              <div className="form-control mt-6 w-96">
-                <label htmlFor="chinchillaName" className="label">
-                  <span className="text-base text-dark-black">チンチラを選択</span>
-                  <div>
-                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                    <span className="label-text-alt text-dark-black">必須入力</span>
-                  </div>
-                </label>
-                <select
-                  id="chinchillaName"
-                  value={chinchillaId}
-                  onChange={(e) => {
-                    handleGetChinchilla(e)
-                  }}
-                  className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-                >
-                  <option hidden value="">
-                    選択してください
-                  </option>
-                  {allChinchillas.map((chinchilla) => (
-                    <option key={chinchilla.id} value={chinchilla.id}>
-                      {chinchilla.chinchillaName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
               {/* 表示モード：お世話の記録 */}
               <div className="mt-6 h-[400px] w-[500px] rounded-xl  bg-ligth-white">
                 {/* 表示モード：食事 */}

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -6,6 +6,7 @@ import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 import { ChinchillaSelectFormItem } from 'src/components/pages/care-record-calendar/chinchillaSelectFormItem'
 import { RadioButtonItem } from 'src/components/pages/care-record-calendar/radioButtonItem'
 import { NumericFormItem } from 'src/components/pages/care-record-calendar/numericFormItem'
+import { CareMemoFormItem } from 'src/components/pages/care-record-calendar/careMemoFormItem'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -363,19 +364,7 @@ export const CareRecordCalendarPage = () => {
           />
 
           {/* 登録モード：お世話のメモ */}
-          <div className="form-control mb-12 mt-6 w-[500px]">
-            <label htmlFor="careMemo" className="mx-1 my-2 flex">
-              <FontAwesomeIcon icon={faFilePen} className="mx-1 pt-[3px] text-lg text-dark-black" />
-              <span className="label-text text-base text-dark-black">メモ</span>
-            </label>
-            <textarea
-              id="careMemo"
-              placeholder="メモを記入してください。"
-              value={careMemo}
-              onChange={(event) => setCareMemo(event.target.value)}
-              className="w-ful textarea textarea-primary h-96 border-dark-blue bg-ligth-white text-base text-dark-black"
-            ></textarea>
-          </div>
+          <CareMemoFormItem careMemo={careMemo} setCareMemo={setCareMemo} />
 
           {/* 登録モード：登録ボタン */}
           <Button
@@ -469,22 +458,7 @@ export const CareRecordCalendarPage = () => {
               />
 
               {/* 編集モード：お世話のメモ */}
-              <div className="form-control mb-12 mt-6 w-[500px]">
-                <label htmlFor="careMemo" className="mx-1 my-2 flex">
-                  <FontAwesomeIcon
-                    icon={faFilePen}
-                    className="mx-1 pt-[3px] text-lg text-dark-black"
-                  />
-                  <span className="label-text text-base text-dark-black">メモ</span>
-                </label>
-                <textarea
-                  id="careMemo"
-                  placeholder="メモを記入してください。"
-                  value={careMemo}
-                  onChange={(event) => setCareMemo(event.target.value)}
-                  className="w-ful textarea textarea-primary h-96 border-dark-blue bg-ligth-white text-base text-dark-black"
-                ></textarea>
-              </div>
+              <CareMemoFormItem careMemo={careMemo} setCareMemo={setCareMemo} />
 
               {/* 編集モード：保存・戻るボタン */}
               <div>

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -200,9 +200,9 @@ export const CareRecordCalendarPage = () => {
     formData.append('care[careToilet]', careToilet)
     formData.append('care[careBath]', careBath)
     formData.append('care[carePlay]', carePlay)
-    formData.append('care[careWeight]', careWeight === undefined ? '' : careWeight)
-    formData.append('care[careTemperature]', careTemperature === undefined ? '' : careTemperature)
-    formData.append('care[careHumidity]', careHumidity === undefined ? '' : careHumidity)
+    formData.append('care[careWeight]', careWeight === null ? '' : careWeight)
+    formData.append('care[careTemperature]', careTemperature === null ? '' : careTemperature)
+    formData.append('care[careHumidity]', careHumidity === null ? '' : careHumidity)
     formData.append('care[careMemo]', careMemo)
     formData.append('care[chinchillaId]', chinchillaId)
     return formData
@@ -254,9 +254,9 @@ export const CareRecordCalendarPage = () => {
     formData.append('care[careToilet]', careToilet)
     formData.append('care[careBath]', careBath)
     formData.append('care[carePlay]', carePlay)
-    formData.append('care[careWeight]', careWeight === undefined ? '' : careWeight)
-    formData.append('care[careTemperature]', careTemperature === undefined ? '' : careTemperature)
-    formData.append('care[careHumidity]', careHumidity === undefined ? '' : careHumidity)
+    formData.append('care[careWeight]', careWeight === null ? '' : careWeight)
+    formData.append('care[careTemperature]', careTemperature === null ? '' : careTemperature)
+    formData.append('care[careHumidity]', careHumidity === null ? '' : careHumidity)
     formData.append('care[careMemo]', careMemo)
     return formData
   }
@@ -357,11 +357,11 @@ export const CareRecordCalendarPage = () => {
               id="careWeight"
               onValueChange={(values) => {
                 // 数値を取り出す
-                setCareWeight(values.floatValue)
+                setCareWeight(values.floatValue ? values.floatValue : null)
               }}
               isAllowed={(values) => {
                 // 入力が空の場合は許容(trueを返す)
-                if (values.floatValue === undefined) return true
+                if (!values.floatValue) return true
 
                 // 1から9999の範囲内であることを確認(trueを返す)
                 return values.floatValue >= 1 && values.floatValue <= 9999
@@ -388,11 +388,11 @@ export const CareRecordCalendarPage = () => {
               id="careTemperature"
               onValueChange={(values) => {
                 // 数値を取り出す
-                setCareTemperature(values.floatValue)
+                setCareTemperature(values.floatValue ? values.floatValue : null)
               }}
               isAllowed={(values) => {
                 // 入力が空の場合は許容(trueを返す)
-                if (values.floatValue === undefined) return true
+                if (!values.floatValue) return true
 
                 // 1から100の範囲内であることを確認(trueを返す)
                 return values.floatValue >= 1 && values.floatValue <= 100
@@ -419,11 +419,11 @@ export const CareRecordCalendarPage = () => {
               id="careHumidity"
               onValueChange={(values) => {
                 // 数値を取り出す
-                setCareHumidity(values.floatValue)
+                setCareHumidity(values.floatValue ? values.floatValue : null)
               }}
               isAllowed={(values) => {
                 // 入力が空の場合は許容(trueを返す)
-                if (values.floatValue === undefined) return true
+                if (!values.floatValue) return true
 
                 // 1から100の範囲内であることを確認(trueを返す)
                 return values.floatValue >= 1 && values.floatValue <= 100
@@ -544,11 +544,11 @@ export const CareRecordCalendarPage = () => {
                   defaultValue={careWeight}
                   onValueChange={(values) => {
                     // 数値を取り出す
-                    setCareWeight(values.floatValue)
+                    setCareWeight(values.floatValue ? values.floatValue : null)
                   }}
                   isAllowed={(values) => {
                     // 入力が空の場合は許容(trueを返す)
-                    if (values.floatValue === undefined) return true
+                    if (!values.floatValue) return true
 
                     // 1から9999の範囲内であることを確認(trueを返す)
                     return values.floatValue >= 1 && values.floatValue <= 9999
@@ -576,11 +576,11 @@ export const CareRecordCalendarPage = () => {
                   defaultValue={careTemperature}
                   onValueChange={(values) => {
                     // 数値を取り出す
-                    setCareTemperature(values.floatValue)
+                    setCareTemperature(values.floatValue ? values.floatValue : null)
                   }}
                   isAllowed={(values) => {
                     // 入力が空の場合は許容(trueを返す)
-                    if (values.floatValue === undefined) return true
+                    if (!values.floatValue) return true
 
                     // 1から100の範囲内であることを確認(trueを返す)
                     return values.floatValue >= 1 && values.floatValue <= 100
@@ -608,11 +608,11 @@ export const CareRecordCalendarPage = () => {
                   defaultValue={careHumidity}
                   onValueChange={(values) => {
                     // 数値を取り出す
-                    setCareHumidity(values.floatValue)
+                    setCareHumidity(values.floatValue ? values.floatValue : null)
                   }}
                   isAllowed={(values) => {
                     // 入力が空の場合は許容(trueを返す)
-                    if (values.floatValue === undefined) return true
+                    if (!values.floatValue) return true
 
                     // 1から100の範囲内であることを確認(trueを返す)
                     return values.floatValue >= 1 && values.floatValue <= 100

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -526,10 +526,8 @@ export const CareRecordCalendarPage = () => {
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">体重</p>
                   <div className="flex grow justify-evenly text-center">
-                    {careWeight ? (
+                    {careWeight && (
                       <p className="text-center text-base text-dark-black">{careWeight}g</p>
-                    ) : (
-                      <></>
                     )}
                   </div>
                 </div>
@@ -538,15 +536,11 @@ export const CareRecordCalendarPage = () => {
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">気温・湿度</p>
                   <div className="flex grow justify-evenly text-center">
-                    {careTemperature ? (
+                    {careTemperature && (
                       <p className="text-center text-base text-dark-black">{careTemperature}℃</p>
-                    ) : (
-                      <></>
                     )}
-                    {careHumidity ? (
+                    {careHumidity && (
                       <p className="text-center text-base text-dark-black">{careHumidity}%</p>
-                    ) : (
-                      <></>
                     )}
                   </div>
                 </div>

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -286,6 +286,15 @@ export const CareRecordCalendarPage = () => {
     }
   }
 
+  // ラジオボタンの削除
+  const handleRadioClick = (setter, currentValue, newValue) => {
+    if (currentValue === newValue) {
+      return setter('')
+    }
+
+    setter(newValue)
+  }
+
   return (
     <div className="my-40 grid place-content-center place-items-center">
       <p className="text-center text-2xl font-bold tracking-widest text-dark-blue">お世話の記録</p>
@@ -711,10 +720,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careFood"
                       value="good"
-                      onChange={(e) => setCareFood(e.target.value)}
+                      checked={careFood === 'good'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careFoodIsGood" className="label cursor-pointer">
+                    <label
+                      htmlFor="careFoodIsGood"
+                      onClick={() => handleRadioClick(setCareFood, careFood, 'good')}
+                      className="label cursor-pointer"
+                    >
                       {careFood === 'good' ? (
                         <FontAwesomeIcon
                           icon={faFaceSmileBeam}
@@ -732,10 +746,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careFood"
                       value="usually"
-                      onChange={(e) => setCareFood(e.target.value)}
+                      checked={careFood === 'usually'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careFoodIsUsually" className="label cursor-pointer">
+                    <label
+                      htmlFor="careFoodIsUsually"
+                      onClick={() => handleRadioClick(setCareFood, careFood, 'usually')}
+                      className="label cursor-pointer"
+                    >
                       {careFood === 'usually' ? (
                         <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
                       ) : (
@@ -747,10 +766,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careFood"
                       value="bad"
-                      onChange={(e) => setCareFood(e.target.value)}
+                      checked={careFood === 'bad'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careFoodIsBad" className="label cursor-pointer">
+                    <label
+                      htmlFor="careFoodIsBad"
+                      onClick={() => handleRadioClick(setCareFood, careFood, 'bad')}
+                      className="label cursor-pointer"
+                    >
                       {careFood === 'bad' ? (
                         <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
                       ) : (
@@ -768,10 +792,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careToilet"
                       value="good"
-                      onChange={(e) => setCareToilet(e.target.value)}
+                      checked={careToilet === 'good'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careToiletIsGood" className="label cursor-pointer">
+                    <label
+                      htmlFor="careToiletIsGood"
+                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'good')}
+                      className="label cursor-pointer"
+                    >
                       {careToilet === 'good' ? (
                         <FontAwesomeIcon
                           icon={faFaceSmileBeam}
@@ -789,10 +818,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careToilet"
                       value="usually"
-                      onChange={(e) => setCareToilet(e.target.value)}
+                      checked={careToilet === 'usually'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careToiletIsUsually" className="label cursor-pointer">
+                    <label
+                      htmlFor="careToiletIsUsually"
+                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'usually')}
+                      className="label cursor-pointer"
+                    >
                       {careToilet === 'usually' ? (
                         <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
                       ) : (
@@ -804,10 +838,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careToilet"
                       value="bad"
-                      onChange={(e) => setCareToilet(e.target.value)}
+                      checked={careToilet === 'bad'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careToiletIsBad" className="label cursor-pointer">
+                    <label
+                      htmlFor="careToiletIsBad"
+                      onClick={() => handleRadioClick(setCareToilet, careToilet, 'bad')}
+                      className="label cursor-pointer"
+                    >
                       {careToilet === 'bad' ? (
                         <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
                       ) : (
@@ -825,10 +864,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careBath"
                       value="good"
-                      onChange={(e) => setCareBath(e.target.value)}
+                      checked={careBath === 'good'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careBathIsGood" className="label cursor-pointer">
+                    <label
+                      htmlFor="careBathIsGood"
+                      onClick={() => handleRadioClick(setCareBath, careBath, 'good')}
+                      className="label cursor-pointer"
+                    >
                       {careBath === 'good' ? (
                         <FontAwesomeIcon
                           icon={faFaceSmileBeam}
@@ -846,10 +890,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careBath"
                       value="usually"
-                      onChange={(e) => setCareBath(e.target.value)}
+                      checked={careBath === 'usually'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careBathIsUsually" className="label cursor-pointer">
+                    <label
+                      htmlFor="careBathIsUsually"
+                      onClick={() => handleRadioClick(setCareBath, careBath, 'usually')}
+                      className="label cursor-pointer"
+                    >
                       {careBath === 'usually' ? (
                         <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
                       ) : (
@@ -861,10 +910,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="careBath"
                       value="bad"
-                      onChange={(e) => setCareBath(e.target.value)}
+                      checked={careBath === 'bad'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="careBathIsBad" className="label cursor-pointer">
+                    <label
+                      htmlFor="careBathIsBad"
+                      onClick={() => handleRadioClick(setCareBath, careBath, 'bad')}
+                      className="label cursor-pointer"
+                    >
                       {careBath === 'bad' ? (
                         <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
                       ) : (
@@ -882,10 +936,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="carePlay"
                       value="good"
-                      onChange={(e) => setCarePlay(e.target.value)}
+                      checked={carePlay === 'good'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="carePlayIsGood" className="label cursor-pointer">
+                    <label
+                      htmlFor="carePlayIsGood"
+                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'good')}
+                      className="label cursor-pointer"
+                    >
                       {carePlay === 'good' ? (
                         <FontAwesomeIcon
                           icon={faFaceSmileBeam}
@@ -903,10 +962,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="carePlay"
                       value="usually"
-                      onChange={(e) => setCarePlay(e.target.value)}
+                      checked={carePlay === 'usually'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="carePlayIsUsually" className="label cursor-pointer">
+                    <label
+                      htmlFor="carePlayIsUsually"
+                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'usually')}
+                      className="label cursor-pointer"
+                    >
                       {carePlay === 'usually' ? (
                         <FontAwesomeIcon icon={faFaceMeh} className="text-2xl text-dark-black" />
                       ) : (
@@ -918,10 +982,15 @@ export const CareRecordCalendarPage = () => {
                       type="radio"
                       name="carePlay"
                       value="bad"
-                      onChange={(e) => setCarePlay(e.target.value)}
+                      checked={carePlay === 'bad'}
+                      onChange={() => {}}
                       className="hidden"
                     />
-                    <label htmlFor="carePlayIsBad" className="label cursor-pointer">
+                    <label
+                      htmlFor="carePlayIsBad"
+                      onClick={() => handleRadioClick(setCarePlay, carePlay, 'bad')}
+                      className="label cursor-pointer"
+                    >
                       {carePlay === 'bad' ? (
                         <FontAwesomeIcon icon={faFaceDizzy} className="text-2xl text-dark-pink" />
                       ) : (

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -4,18 +4,14 @@ import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/car
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { ChinchillaSelectFormItem } from 'src/components/pages/care-record-calendar/chinchillaSelectFormItem'
-import { RadioButtonItem } from 'src/components/pages/care-record-calendar/radioButtonItem'
+import { InputRadioButtonItem } from 'src/components/pages/care-record-calendar/inputRadioButtonItem'
+import { DisplayRadioButtonItem } from 'src/components/pages/care-record-calendar/displayRadioButtonItem'
 import { NumericFormItem } from 'src/components/pages/care-record-calendar/numericFormItem'
 import { CareMemoFormItem } from 'src/components/pages/care-record-calendar/careMemoFormItem'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faFaceSmileBeam,
-  faFaceDizzy,
-  faFaceMeh,
-  faFilePen
-} from '@fortawesome/free-solid-svg-icons'
+import { faFilePen } from '@fortawesome/free-solid-svg-icons'
 
 import { Calendar } from 'src/components/pages/care-record-calendar/calendar'
 import { format } from 'date-fns'
@@ -313,15 +309,30 @@ export const CareRecordCalendarPage = () => {
         <>
           {/* 登録モード：お世話の記録 */}
           <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
-            <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
-            <RadioButtonItem
+            <InputRadioButtonItem
+              label="食事"
+              item="Food"
+              value={careFood}
+              setValue={setCareFood}
+            />
+            <InputRadioButtonItem
               label="トイレ"
               item="Toilet"
               value={careToilet}
               setValue={setCareToilet}
             />
-            <RadioButtonItem label="砂浴び" item="Bath" value={careBath} setValue={setCareBath} />
-            <RadioButtonItem label="部屋んぽ" item="Play" value={carePlay} setValue={setCarePlay} />
+            <InputRadioButtonItem
+              label="砂浴び"
+              item="Bath"
+              value={careBath}
+              setValue={setCareBath}
+            />
+            <InputRadioButtonItem
+              label="部屋んぽ"
+              item="Play"
+              value={carePlay}
+              setValue={setCarePlay}
+            />
           </div>
 
           {/* 登録モード：体重 */}
@@ -397,20 +408,25 @@ export const CareRecordCalendarPage = () => {
             <>
               {/* 編集モード：お世話の記録 */}
               <div className="mt-6 h-[300px] w-[500px] rounded-xl border border-solid border-dark-blue bg-ligth-white">
-                <RadioButtonItem label="食事" item="Food" value={careFood} setValue={setCareFood} />
-                <RadioButtonItem
+                <InputRadioButtonItem
+                  label="食事"
+                  item="Food"
+                  value={careFood}
+                  setValue={setCareFood}
+                />
+                <InputRadioButtonItem
                   label="トイレ"
                   item="Toilet"
                   value={careToilet}
                   setValue={setCareToilet}
                 />
-                <RadioButtonItem
+                <InputRadioButtonItem
                   label="砂浴び"
                   item="Bath"
                   value={careBath}
                   setValue={setCareBath}
                 />
-                <RadioButtonItem
+                <InputRadioButtonItem
                   label="部屋んぽ"
                   item="Play"
                   value={carePlay}
@@ -501,162 +517,11 @@ export const CareRecordCalendarPage = () => {
             <>
               {/* 表示モード：お世話の記録 */}
               <div className="mt-6 h-[400px] w-[500px] rounded-xl  bg-ligth-white">
-                {/* 表示モード：食事 */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">食事</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    {careFood === 'good' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-dark-blue"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careFood === 'usually' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-dark-black"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careFood === 'bad' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-dark-pink"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                  </div>
-                </div>
-                {/* 表示モード：トイレ */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">トイレ</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    {careToilet === 'good' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-dark-blue"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careToilet === 'usually' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-dark-black"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careToilet === 'bad' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-dark-pink"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                  </div>
-                </div>
-                {/* 表示モード：砂浴び */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">砂浴び</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    {careBath === 'good' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-dark-blue"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careBath === 'usually' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-dark-black"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {careBath === 'bad' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-dark-pink"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                  </div>
-                </div>
-                {/* 表示モード：部屋んぽ */}
-                <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
-                  <p className="w-28 text-center text-base text-dark-black">部屋んぽ</p>
-                  <div className="flex grow justify-evenly text-center text-base text-dark-black">
-                    {carePlay === 'good' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-dark-blue"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceSmileBeam}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {carePlay === 'usually' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-dark-black"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceMeh}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                    {carePlay === 'bad' ? (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-dark-pink"
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faFaceDizzy}
-                        className="label text-2xl text-light-black"
-                      />
-                    )}
-                  </div>
-                </div>
+                <DisplayRadioButtonItem label="食事" item="careFood" value={careFood} />
+                <DisplayRadioButtonItem label="トイレ" item="careToilet" value={careToilet} />
+                <DisplayRadioButtonItem label="砂浴び" item="careBath" value={careBath} />
+                <DisplayRadioButtonItem label="部屋んぽ" item="carePlay" value={carePlay} />
+
                 {/* 表示モード：体重 */}
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">体重</p>
@@ -668,6 +533,7 @@ export const CareRecordCalendarPage = () => {
                     )}
                   </div>
                 </div>
+
                 {/* 表示モード：気温・湿度 */}
                 <div className="mx-10 mt-5 flex items-center border-b border-solid border-b-light-black pb-2">
                   <p className="w-28 text-center text-base text-dark-black">気温・湿度</p>

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -4,8 +4,7 @@ import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/car
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { RadioButtonItem } from 'src/components/pages/care-record-calendar/radioButtonItem'
-
-import { NumericFormat } from 'react-number-format'
+import { NumericFormItem } from 'src/components/pages/care-record-calendar/numericFormItem'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -345,97 +344,43 @@ export const CareRecordCalendarPage = () => {
           </div>
 
           {/* 登録モード：体重 */}
-          <div className="form-control mt-6 w-96">
-            <label htmlFor="careWeight" className="label">
-              <span className="text-base text-dark-black">体重（g）</span>
-              <div>
-                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                <span className="label-text-alt text-dark-black">半角数字</span>
-              </div>
-            </label>
-            <NumericFormat
-              id="careWeight"
-              onValueChange={(values) => {
-                // 数値を取り出す
-                setCareWeight(values.floatValue ? values.floatValue : null)
-              }}
-              isAllowed={(values) => {
-                // 入力が空の場合は許容(trueを返す)
-                if (!values.floatValue) return true
-
-                // 1から9999の範囲内であることを確認(trueを返す)
-                return values.floatValue >= 1 && values.floatValue <= 9999
-              }}
-              placeholder="500"
-              thousandSeparator=","
-              allowNegative={false}
-              decimalScale={0}
-              suffix={'g'}
-              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-            />
-          </div>
+          <NumericFormItem
+            label="体重（g）"
+            item="careWeight"
+            value={careWeight}
+            setValue={setCareWeight}
+            min={1}
+            max={9999}
+            placeholder="500"
+            decimalScale={0}
+            suffix="g"
+          />
 
           {/* 登録モード：気温 */}
-          <div className="form-control mt-6 w-96">
-            <label htmlFor="careTemperature" className="label">
-              <span className="text-base text-dark-black">気温（℃）</span>
-              <div>
-                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                <span className="label-text-alt text-dark-black">半角数字</span>
-              </div>
-            </label>
-            <NumericFormat
-              id="careTemperature"
-              onValueChange={(values) => {
-                // 数値を取り出す
-                setCareTemperature(values.floatValue ? values.floatValue : null)
-              }}
-              isAllowed={(values) => {
-                // 入力が空の場合は許容(trueを返す)
-                if (!values.floatValue) return true
-
-                // 1から100の範囲内であることを確認(trueを返す)
-                return values.floatValue >= 1 && values.floatValue <= 100
-              }}
-              placeholder="21.5"
-              thousandSeparator=","
-              allowNegative={false}
-              decimalScale={1}
-              suffix={'℃'}
-              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-            />
-          </div>
+          <NumericFormItem
+            label="気温（℃）"
+            item="careTemperature"
+            value={careTemperature}
+            setValue={setCareTemperature}
+            min={1}
+            max={100}
+            placeholder="21.5"
+            decimalScale={1}
+            suffix="℃"
+          />
 
           {/* 登録モード：湿度 */}
-          <div className="form-control mt-6 w-96">
-            <label htmlFor="careHumidity" className="label">
-              <span className="text-base text-dark-black">湿度（%）</span>
-              <div>
-                <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                <span className="label-text-alt text-dark-black">半角数字</span>
-              </div>
-            </label>
-            <NumericFormat
-              id="careHumidity"
-              onValueChange={(values) => {
-                // 数値を取り出す
-                setCareHumidity(values.floatValue ? values.floatValue : null)
-              }}
-              isAllowed={(values) => {
-                // 入力が空の場合は許容(trueを返す)
-                if (!values.floatValue) return true
-
-                // 1から100の範囲内であることを確認(trueを返す)
-                return values.floatValue >= 1 && values.floatValue <= 100
-              }}
-              placeholder="40"
-              thousandSeparator=","
-              allowNegative={false}
-              decimalScale={0}
-              suffix={'%'}
-              className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-            />
-          </div>
+          <NumericFormItem
+            label="湿度（%）"
+            item="careHumidity"
+            value={careHumidity}
+            setValue={setCareHumidity}
+            min={1}
+            max={100}
+            placeholder="40"
+            decimalScale={0}
+            suffix="%"
+          />
 
           {/* 登録モード：お世話のメモ */}
           <div className="form-control mb-12 mt-6 w-[500px]">
@@ -531,100 +476,43 @@ export const CareRecordCalendarPage = () => {
               </div>
 
               {/* 編集モード：体重 */}
-              <div className="form-control mt-6 w-96">
-                <label htmlFor="careWeight" className="label">
-                  <span className="text-base text-dark-black">体重（g）</span>
-                  <div>
-                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                    <span className="label-text-alt text-dark-black">半角数字</span>
-                  </div>
-                </label>
-                <NumericFormat
-                  id="careWeight"
-                  defaultValue={careWeight}
-                  onValueChange={(values) => {
-                    // 数値を取り出す
-                    setCareWeight(values.floatValue ? values.floatValue : null)
-                  }}
-                  isAllowed={(values) => {
-                    // 入力が空の場合は許容(trueを返す)
-                    if (!values.floatValue) return true
-
-                    // 1から9999の範囲内であることを確認(trueを返す)
-                    return values.floatValue >= 1 && values.floatValue <= 9999
-                  }}
-                  placeholder="500"
-                  thousandSeparator=","
-                  allowNegative={false}
-                  decimalScale={0}
-                  suffix={'g'}
-                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-                />
-              </div>
+              <NumericFormItem
+                label="体重（g）"
+                item="careWeight"
+                value={careWeight}
+                setValue={setCareWeight}
+                min={1}
+                max={9999}
+                placeholder="500"
+                decimalScale={0}
+                suffix="g"
+              />
 
               {/* 編集モード：気温 */}
-              <div className="form-control mt-6 w-96">
-                <label htmlFor="careTemperature" className="label">
-                  <span className="text-base text-dark-black">気温（℃）</span>
-                  <div>
-                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                    <span className="label-text-alt text-dark-black">半角数字</span>
-                  </div>
-                </label>
-                <NumericFormat
-                  id="careTemperature"
-                  defaultValue={careTemperature}
-                  onValueChange={(values) => {
-                    // 数値を取り出す
-                    setCareTemperature(values.floatValue ? values.floatValue : null)
-                  }}
-                  isAllowed={(values) => {
-                    // 入力が空の場合は許容(trueを返す)
-                    if (!values.floatValue) return true
-
-                    // 1から100の範囲内であることを確認(trueを返す)
-                    return values.floatValue >= 1 && values.floatValue <= 100
-                  }}
-                  placeholder="21.5"
-                  thousandSeparator=","
-                  allowNegative={false}
-                  decimalScale={1}
-                  suffix={'℃'}
-                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-                />
-              </div>
+              <NumericFormItem
+                label="気温（℃）"
+                item="careTemperature"
+                value={careTemperature}
+                setValue={setCareTemperature}
+                min={1}
+                max={100}
+                placeholder="21.5"
+                decimalScale={1}
+                suffix="℃"
+              />
 
               {/* 編集モード：湿度 */}
-              <div className="form-control mt-6 w-96">
-                <label htmlFor="careHumidity" className="label">
-                  <span className="text-base text-dark-black">湿度（%）</span>
-                  <div>
-                    <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
-                    <span className="label-text-alt text-dark-black">半角数字</span>
-                  </div>
-                </label>
-                <NumericFormat
-                  id="careHumidity"
-                  defaultValue={careHumidity}
-                  onValueChange={(values) => {
-                    // 数値を取り出す
-                    setCareHumidity(values.floatValue ? values.floatValue : null)
-                  }}
-                  isAllowed={(values) => {
-                    // 入力が空の場合は許容(trueを返す)
-                    if (!values.floatValue) return true
-
-                    // 1から100の範囲内であることを確認(trueを返す)
-                    return values.floatValue >= 1 && values.floatValue <= 100
-                  }}
-                  placeholder="40"
-                  thousandSeparator=","
-                  allowNegative={false}
-                  decimalScale={0}
-                  suffix={'%'}
-                  className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
-                />
-              </div>
+              <NumericFormItem
+                label="湿度（%）"
+                item="careHumidity"
+                value={careHumidity}
+                setValue={setCareHumidity}
+                min={1}
+                max={100}
+                placeholder="40"
+                decimalScale={0}
+                suffix="%"
+              />
 
               {/* 編集モード：お世話のメモ */}
               <div className="form-control mb-12 mt-6 w-[500px]">

--- a/frontend/src/components/pages/care-record-calendar/inputRadioButtonItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/inputRadioButtonItem.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFaceSmileBeam, faFaceDizzy, faFaceMeh } from '@fortawesome/free-solid-svg-icons'
 
-export const RadioButtonItem = ({ label, item, value, setValue }) => {
+export const InputRadioButtonItem = ({ label, item, value, setValue }) => {
   // ラジオボタンの取り消し
   const handleRadioClick = (setter, currentValue, newValue) => {
     if (currentValue === newValue) {

--- a/frontend/src/components/pages/care-record-calendar/numericFormItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/numericFormItem.jsx
@@ -1,0 +1,49 @@
+import { NumericFormat } from 'react-number-format'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
+
+export const NumericFormItem = ({
+  label,
+  item,
+  value,
+  setValue,
+  min,
+  max,
+  placeholder,
+  decimalScale,
+  suffix
+}) => {
+  return (
+    <div className="form-control mt-6 w-96">
+      <label htmlFor={item} className="label">
+        <span className="text-base text-dark-black">{label}</span>
+        <div>
+          <FontAwesomeIcon icon={faAsterisk} className="mr-1 text-xs text-dark-pink" />
+          <span className="label-text-alt text-dark-black">半角数字</span>
+        </div>
+      </label>
+      <NumericFormat
+        id={item}
+        defaultValue={value}
+        onValueChange={(values) => {
+          // 入力が空(undafined)になる場合はnullをセット
+          setValue(values.floatValue === undefined ? null : values.floatValue)
+        }}
+        isAllowed={(values) => {
+          // 入力が空(undafined)の場合は許容(trueを返す)
+          if (values.floatValue === undefined) return true
+
+          // 1から9999の範囲内であることを確認(trueを返す)
+          return values.floatValue >= min && values.floatValue <= max
+        }}
+        placeholder={placeholder}
+        thousandSeparator=","
+        allowNegative={false}
+        decimalScale={decimalScale}
+        suffix={suffix}
+        className="w-ful input input-bordered input-primary input-md border-dark-blue bg-ligth-white text-base text-dark-black"
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/pages/care-record-calendar/radioButtonItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/radioButtonItem.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFaceSmileBeam, faFaceDizzy, faFaceMeh } from '@fortawesome/free-solid-svg-icons'
+
+export const RadioButtonItem = ({ label, item, value, setValue }) => {
+  // ラジオボタンの取り消し
+  const handleRadioClick = (setter, currentValue, newValue) => {
+    if (currentValue === newValue) {
+      return setter('')
+    }
+
+    setter(newValue)
+  }
+
+  return (
+    <div className="mx-10 mt-6 flex items-center border-b border-solid border-b-light-black">
+      <p className="w-28 text-center text-base text-dark-black">{label}</p>
+      <div className="flex grow justify-evenly text-center text-base text-dark-black">
+        {['good', 'usually', 'bad'].map((status) => (
+          <React.Fragment key={`care${item}Is${status}`}>
+            <input
+              id={`care${item}Is${status}`}
+              type="radio"
+              name={`care${item}`}
+              value={status}
+              checked={value === status}
+              onChange={() => {}}
+              className="hidden"
+            />
+            <label
+              htmlFor={`care${item}Is${status}`}
+              onClick={() => handleRadioClick(setValue, value, status)}
+              className="label cursor-pointer"
+            >
+              {value === status ? (
+                <FontAwesomeIcon
+                  icon={
+                    status === 'good'
+                      ? faFaceSmileBeam
+                      : status === 'usually'
+                      ? faFaceMeh
+                      : faFaceDizzy
+                  }
+                  className={`text-2xl ${
+                    value === status
+                      ? status === 'good'
+                        ? 'text-dark-blue'
+                        : status === 'bad'
+                        ? 'text-dark-pink'
+                        : 'text-dark-black'
+                      : 'text-light-black'
+                  }`}
+                />
+              ) : (
+                <FontAwesomeIcon
+                  icon={
+                    status === 'good'
+                      ? faFaceSmileBeam
+                      : status === 'usually'
+                      ? faFaceMeh
+                      : faFaceDizzy
+                  }
+                  className="text-2xl text-light-black"
+                />
+              )}
+            </label>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)で複数の修正を行いました。


### 修正前：
- ラジオボタンで一度選択すると解除ができない。
- #36  の修正の結果、DBから値をとってきた際にnullになることを考慮しておらず、体重・気温・数値について、未入力が登録できないケースがある。
- 同じようなコードがコピペされており、可読性が低い。 

### 修正後：
- 選択中のラジオボタンをもう一度クリックすると選択状態を取り消せるようにしました。
- 数値の扱いを修正し、バグを解消しました。
- アイテムごとにコンポーネント化し、リファクタリングしました。

### 修正理由：
- UX向上のため。
- 意図しない挙動をしたため。
- コードの保守性を向上させるため。

## 実装概要
- ラジオボタンの取り消し機能を追加 `1105dbe`
- 体温・気温・湿度の未入力時のバグ修正 `043cd68`
- リファクタリング `6d6d5c0` `761fe0e` `e42b46e` `8624044` `8ecddb0` `76fed45`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] バグフィックス
- [x] リファクタリング
- [ ] 仕様変更
