### PR TITLE
チンチラプロフィールページの複数の修正

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
+        "date-fns-tz": "^2.0.0",
         "eslint": "8.45.0",
         "eslint-config-next": "13.4.12",
         "js-cookie": "^3.0.5",
@@ -1278,6 +1279,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.12",
     "js-cookie": "^3.0.5",

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.jsx
@@ -1,0 +1,8 @@
+export const DisplayChinchillaProfileItem = ({ label, value }) => {
+  return (
+    <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
+      <p className="w-24 text-center text-base text-dark-black">{label}</p>
+      <p className="grow text-center text-base text-dark-black">{value}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.jsx
@@ -1,7 +1,7 @@
 export const DisplayChinchillaProfileItem = ({ label, value }) => {
   return (
-    <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
-      <p className="w-24 text-center text-base text-dark-black">{label}</p>
+    <div className="mx-10 mt-5 flex border-b border-solid border-b-light-black pb-2">
+      <p className="w-28 text-center text-base text-dark-black">{label}</p>
       <p className="grow text-center text-base text-dark-black">{value}</p>
     </div>
   )

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -321,7 +321,7 @@ export const ChinchillaProfilePage = () => {
               <DisplayChinchillaProfileItem label="性別" value={selectedChinchilla.chinchillaSex} />
               <DisplayChinchillaProfileItem
                 label="誕生日"
-                value={selectedChinchilla.chinchillaBirthday.replace(/-/g, '/')}
+                value={selectedChinchilla.chinchillaBirthday?.replace(/-/g, '/')}
               />
               <DisplayChinchillaProfileItem
                 label="年齢"
@@ -329,7 +329,7 @@ export const ChinchillaProfilePage = () => {
               />
               <DisplayChinchillaProfileItem
                 label="お迎え日"
-                value={selectedChinchilla.chinchillaMetDay.replace(/-/g, '/')}
+                value={selectedChinchilla.chinchillaMetDay?.replace(/-/g, '/')}
               />
             </div>
             <div className="my-12">

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router'
 import { getChinchilla, updateChinchilla, deleteChinchilla } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
+import { DisplayChinchillaProfileItem } from 'src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem'
+
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { chinchillaProfileSchema } from 'src/validation/chinchilla'
@@ -295,30 +297,19 @@ export const ChinchillaProfilePage = () => {
               />
             </div>
             <div className="mt-8 h-[230px] w-[500px] rounded-xl bg-ligth-white">
-              <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
-                <p className="w-24 text-center text-base text-dark-black">名前</p>
-                <p className="grow text-center text-base text-dark-black">
-                  {selectedChinchilla.chinchillaName}
-                </p>
-              </div>
-              <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
-                <p className="w-24 text-center text-base text-dark-black">性別</p>
-                <p className="grow text-center text-base text-dark-black">
-                  {selectedChinchilla.chinchillaSex}
-                </p>
-              </div>
-              <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
-                <p className="w-24 text-center text-base text-dark-black">誕生日</p>
-                <p className="grow text-center text-base text-dark-black">
-                  {selectedChinchilla.chinchillaBirthday}
-                </p>
-              </div>
-              <div className="mx-10 mt-6 flex border-b border-solid border-b-light-black">
-                <p className="w-24 text-center text-base text-dark-black">お迎え日</p>
-                <p className="grow text-center text-base text-dark-black">
-                  {selectedChinchilla.chinchillaMetDay}
-                </p>
-              </div>
+              <DisplayChinchillaProfileItem
+                label="名前"
+                value={selectedChinchilla.chinchillaName}
+              />
+              <DisplayChinchillaProfileItem label="性別" value={selectedChinchilla.chinchillaSex} />
+              <DisplayChinchillaProfileItem
+                label="誕生日"
+                value={selectedChinchilla.chinchillaBirthday}
+              />
+              <DisplayChinchillaProfileItem
+                label="お迎え日"
+                value={selectedChinchilla.chinchillaMetDay}
+              />
             </div>
             <div className="my-12">
               <div className="mx-1 my-2 flex">

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -313,7 +313,7 @@ export const ChinchillaProfilePage = () => {
                 className="h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
               />
             </div>
-            <div className="mt-8 h-[275px] w-[500px] rounded-xl bg-ligth-white">
+            <div className="mt-8 h-[290px] w-[500px] rounded-xl bg-ligth-white">
               <DisplayChinchillaProfileItem
                 label="名前"
                 value={selectedChinchilla.chinchillaName}
@@ -321,7 +321,7 @@ export const ChinchillaProfilePage = () => {
               <DisplayChinchillaProfileItem label="性別" value={selectedChinchilla.chinchillaSex} />
               <DisplayChinchillaProfileItem
                 label="誕生日"
-                value={selectedChinchilla.chinchillaBirthday}
+                value={selectedChinchilla.chinchillaBirthday.replace(/-/g, '/')}
               />
               <DisplayChinchillaProfileItem
                 label="年齢"
@@ -329,7 +329,7 @@ export const ChinchillaProfilePage = () => {
               />
               <DisplayChinchillaProfileItem
                 label="お迎え日"
-                value={selectedChinchilla.chinchillaMetDay}
+                value={selectedChinchilla.chinchillaMetDay.replace(/-/g, '/')}
               />
             </div>
             <div className="my-12">

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -9,12 +9,16 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { chinchillaProfileSchema } from 'src/validation/chinchilla'
 
+import { differenceInYears, differenceInMonths } from 'date-fns'
+import { utcToZonedTime } from 'date-fns-tz'
+
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAsterisk, faCirclePlus, faFilePen } from '@fortawesome/free-solid-svg-icons'
 
 export const ChinchillaProfilePage = () => {
   const router = useRouter()
+  const JAPAN_TIMEZONE = 'Asia/Tokyo'
 
   //選択中のチンチラの状態管理（グローバル）
   const [selectedChinchilla, setSelectedChinchilla] = useState([])
@@ -96,6 +100,19 @@ export const ChinchillaProfilePage = () => {
       return selectedChinchilla.chinchillaImage.url
     }
     return '/images/default.svg'
+  }
+
+  // 年齢を計算する関数
+  const calculateAge = (birthdayStr) => {
+    if (!birthdayStr) return ''
+
+    const birthday = new Date(birthdayStr)
+    const nowInJapan = utcToZonedTime(new Date(), JAPAN_TIMEZONE)
+
+    let ageYear = differenceInYears(nowInJapan, birthday)
+    let ageMonth = differenceInMonths(nowInJapan, birthday) % 12
+
+    return `${ageYear}歳${ageMonth}ヶ月`
   }
 
   // FormData形式でデータを作成
@@ -296,7 +313,7 @@ export const ChinchillaProfilePage = () => {
                 className="h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
               />
             </div>
-            <div className="mt-8 h-[230px] w-[500px] rounded-xl bg-ligth-white">
+            <div className="mt-8 h-[275px] w-[500px] rounded-xl bg-ligth-white">
               <DisplayChinchillaProfileItem
                 label="名前"
                 value={selectedChinchilla.chinchillaName}
@@ -305,6 +322,10 @@ export const ChinchillaProfilePage = () => {
               <DisplayChinchillaProfileItem
                 label="誕生日"
                 value={selectedChinchilla.chinchillaBirthday}
+              />
+              <DisplayChinchillaProfileItem
+                label="年齢"
+                value={calculateAge(selectedChinchilla.chinchillaBirthday)}
               />
               <DisplayChinchillaProfileItem
                 label="お迎え日"

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -34,6 +34,7 @@ export const ChinchillaProfilePage = () => {
     register,
     setValue,
     handleSubmit,
+    clearErrors,
     formState: { errors }
   } = useForm({
     defaultValues: {
@@ -291,6 +292,7 @@ export const ChinchillaProfilePage = () => {
                 type="button"
                 click={() => {
                   setIsEditing(false)
+                  clearErrors()
                   setPreviewImage('')
                   setChinchillaImage('')
                 }}

--- a/frontend/src/validation/chinchilla.js
+++ b/frontend/src/validation/chinchilla.js
@@ -1,4 +1,8 @@
 import { z } from 'zod'
+import { utcToZonedTime, format } from 'date-fns-tz'
+
+// 日本のタイムゾーンを取得
+const toJST = (date) => utcToZonedTime(date, 'Asia/Tokyo')
 
 export const chinchillaRegistrationSchema = z
   .object({
@@ -11,19 +15,39 @@ export const chinchillaRegistrationSchema = z
     chinchillaMetDay: z.string().nullable()
   })
   // 第一引数の条件がfalseの場合に、第二引数のメッセージを表示
-  .refine((data) => !data.chinchillaBirthday || new Date(data.chinchillaBirthday) <= new Date(), {
-    message: '誕生日は未来の日付に設定できません',
-    path: ['chinchillaBirthday']
-  })
-  .refine((data) => !data.chinchillaMetDay || new Date(data.chinchillaMetDay) <= new Date(), {
-    message: 'お迎え日は未来の日付に設定できません',
-    path: ['chinchillaMetDay']
-  })
+  .refine(
+    (data) => {
+      const currentJSTDate = toJST(new Date())
+      const formattedCurrentJSTDate = format(currentJSTDate, 'yyyy-MM-dd', {
+        timeZone: 'Asia/Tokyo'
+      })
+
+      return !data.chinchillaBirthday || data.chinchillaBirthday <= formattedCurrentJSTDate
+    },
+    {
+      message: '誕生日は未来の日付に設定できません',
+      path: ['chinchillaBirthday']
+    }
+  )
+  .refine(
+    (data) => {
+      const currentJSTDate = toJST(new Date())
+      const formattedCurrentJSTDate = format(currentJSTDate, 'yyyy-MM-dd', {
+        timeZone: 'Asia/Tokyo'
+      })
+
+      return !data.chinchillaMetDay || data.chinchillaMetDay <= formattedCurrentJSTDate
+    },
+    {
+      message: 'お迎え日は未来の日付に設定できません',
+      path: ['chinchillaMetDay']
+    }
+  )
   .refine(
     (data) =>
       !data.chinchillaBirthday ||
       !data.chinchillaMetDay ||
-      new Date(data.chinchillaBirthday) <= new Date(data.chinchillaMetDay),
+      data.chinchillaBirthday <= data.chinchillaMetDay,
     {
       message: 'お迎え日は誕生日以降の日付で設定してください',
       path: ['chinchillaMetDay']
@@ -43,20 +67,28 @@ export const chinchillaProfileSchema = z
   })
   // 第一引数の条件がfalseの場合に、第二引数のメッセージを表示
   .refine(
-    (data) =>
-      !data.chinchillaBirthday ||
-      new Date(data.chinchillaBirthday) <=
-        new Date(),
+    (data) => {
+      const currentJSTDate = toJST(new Date())
+      const formattedCurrentJSTDate = format(currentJSTDate, 'yyyy-MM-dd', {
+        timeZone: 'Asia/Tokyo'
+      })
+
+      return !data.chinchillaBirthday || data.chinchillaBirthday <= formattedCurrentJSTDate
+    },
     {
       message: '誕生日は未来の日付に設定できません',
       path: ['chinchillaBirthday']
     }
   )
   .refine(
-    (data) =>
-      !data.chinchillaMetDay ||
-      new Date(data.chinchillaMetDay)<=
-        new Date(),
+    (data) => {
+      const currentJSTDate = toJST(new Date())
+      const formattedCurrentJSTDate = format(currentJSTDate, 'yyyy-MM-dd', {
+        timeZone: 'Asia/Tokyo'
+      })
+
+      return !data.chinchillaMetDay || data.chinchillaMetDay <= formattedCurrentJSTDate
+    },
     {
       message: 'お迎え日は未来の日付に設定できません',
       path: ['chinchillaMetDay']
@@ -66,7 +98,7 @@ export const chinchillaProfileSchema = z
     (data) =>
       !data.chinchillaBirthday ||
       !data.chinchillaMetDay ||
-      new Date(data.chinchillaBirthday) <= new Date(data.chinchillaMetDay),
+      data.chinchillaBirthday <= data.chinchillaMetDay,
     {
       message: 'お迎え日は誕生日以降の日付で設定してください',
       path: ['chinchillaMetDay']


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)について、複数の修正を行いました。


### 修正前：
- 同じようなコードがコピペされており、可読性が低い。 
- チンチラの誕生日・お迎え日をyyyy-mm-dd形式で表示している。
- チンチラの誕生日・お迎え日のバリデーションスキーマにおいて、日付をUTCで比較しており、特定の時間帯で条件を満たしているにもかかわらず、エラーメッセージが表示される。
- バリデーションのエラーメッセージを表示した状態で、「戻る」ボタンを押し、再度「編集」ボタンを押すと、以前の入力がリセットされているにもかかわらず、エラー状態がリセットされていない。

### 修正後：
- アイテムごとにコンポーネント化し、リファクタリングしました。
- チンチラの年齢を表示しました。
- チンチラの誕生日・お迎え日をyyyy/mm/dd形式で表示しました。
- チンチラの誕生日・お迎え日をJSTで比較するようにバリデーションスキーマを修正しました。(`/chinchilla-registration`も同様に修正)
- 「戻る」ボタンを押したタイミングで、バリデーションエラー状態をリセットするよう修正しました。

### 修正理由：
- コードの保守性を向上させるため。
- UX向上のため。
- 意図しない挙動をしたため。

## 実装概要
- リファクタリング `ed9e1a9`
- チンチラの年齢を表示・修正 `6db7878` `963b21d`
- チンチラの誕生日・お迎え日の表示方法を修正 `275f491`
- チンチラの誕生日・お迎え日をJSTで比較するようにバリデーションスキーマを修正 `452f15f`
-  「戻る」ボタンを押したタイミングで、バリデーションエラー状態をリセットするよう修正 `3ed379b`

# スクリーンショット



| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-10-07 17 48 03](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/52ffcb52-7f82-4525-8ae6-fde20497af88) |  ![スクリーンショット 2023-10-07 17 47 36](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/6b61bb9c-4688-4af9-bac5-3168a97fc708) |

# 変更のタイプ
- [x] 新機能
- [x] バグフィックス
- [x] リファクタリング
- [ ] 仕様変更
