### PR TITLE
削除確認用のモーダルを追加

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -8,6 +8,7 @@ import { InputRadioButtonItem } from 'src/components/pages/care-record-calendar/
 import { DisplayRadioButtonItem } from 'src/components/pages/care-record-calendar/displayRadioButtonItem'
 import { NumericFormItem } from 'src/components/pages/care-record-calendar/numericFormItem'
 import { CareMemoFormItem } from 'src/components/pages/care-record-calendar/careMemoFormItem'
+import { DeleteConfirmationModal } from 'src/components/shared/DeleteConfirmationModal'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -27,6 +28,9 @@ export const CareRecordCalendarPage = () => {
 
   // 編集モードの状態管理
   const [isEditing, setIsEditing] = useState(false)
+
+  // 削除確認用モーダルの状態管理
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   // 入力内容の状態管理
   const [careFood, setCareFood] = useState('')
@@ -166,6 +170,8 @@ export const CareRecordCalendarPage = () => {
       setCareTemperature(null)
       setCareHumidity(null)
       setCareMemo('')
+
+      setIsModalOpen(false)
     } catch (err) {
       console.log(err)
       alert('エラーです')
@@ -574,10 +580,22 @@ export const CareRecordCalendarPage = () => {
                 >
                   編集
                 </Button>
-                <Button btnType="submit" click={handleDelete} addStyle="btn-secondary h-16 w-40">
+                <Button
+                  btnType="submit"
+                  click={() => setIsModalOpen(true)}
+                  addStyle="btn-secondary h-16 w-40"
+                >
                   削除
                 </Button>
               </div>
+
+              {/* 削除確認モーダル */}
+              {isModalOpen && (
+                <DeleteConfirmationModal
+                  setIsModalOpen={setIsModalOpen}
+                  handleDelete={handleDelete}
+                />
+              )}
             </>
           )}
         </>

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -4,6 +4,7 @@ import { getChinchilla, updateChinchilla, deleteChinchilla } from 'src/lib/api/c
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { DisplayChinchillaProfileItem } from 'src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem'
+import { DeleteConfirmationModal } from 'src/components/shared/DeleteConfirmationModal'
 
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -26,6 +27,9 @@ export const ChinchillaProfilePage = () => {
 
   // 編集モードの状態管理
   const [isEditing, setIsEditing] = useState(false)
+
+  // 削除確認用モーダルの状態管理
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   // 入力内容の状態管理
   const [chinchillaImage, setChinchillaImage] = useState(selectedChinchilla.chinchillaImage)
@@ -163,6 +167,7 @@ export const ChinchillaProfilePage = () => {
       const res = await deleteChinchilla(chinchillaId)
       console.log(res)
       setChinchillaId(0)
+      setIsModalOpen(false)
       router.replace('/mychinchilla')
     } catch (err) {
       console.log(err)
@@ -363,10 +368,22 @@ export const ChinchillaProfilePage = () => {
               >
                 編集
               </Button>
-              <Button type="submit" click={handleDelete} addStyle="btn-secondary h-16 w-40">
+              <Button
+                type="button"
+                click={() => setIsModalOpen(true)}
+                addStyle="btn-secondary h-16 w-40"
+              >
                 削除
               </Button>
             </div>
+
+            {/* 削除確認モーダル */}
+            {isModalOpen && (
+              <DeleteConfirmationModal
+                setIsModalOpen={setIsModalOpen}
+                handleDelete={handleDelete}
+              />
+            )}
           </>
         )}
       </form>

--- a/frontend/src/components/shared/DeleteConfirmationModal.jsx
+++ b/frontend/src/components/shared/DeleteConfirmationModal.jsx
@@ -11,7 +11,7 @@ export const DeleteConfirmationModal = ({ setIsModalOpen, handleDelete }) => {
             <Button
               type="button"
               click={() => setIsModalOpen(false)}
-              addStyle="btn-primary w-32 h-14 mr-10"
+              addStyle="btn-ghost bg-gray-200 w-32 h-14 mr-10"
             >
               キャンセル
             </Button>

--- a/frontend/src/components/shared/DeleteConfirmationModal.jsx
+++ b/frontend/src/components/shared/DeleteConfirmationModal.jsx
@@ -1,0 +1,26 @@
+import { Button } from 'src/components/shared/Button'
+
+export const DeleteConfirmationModal = ({ setIsModalOpen, handleDelete }) => {
+  return (
+    <>
+      {/* 削除確認モーダル */}
+      <div className="fixed inset-0 flex h-full w-full items-center justify-center  bg-gray-400/50">
+        <div className="z-10 grid h-1/5 w-1/2 place-content-center place-items-center rounded-lg bg-ligth-white p-5">
+          <p className="text-lg text-dark-black">本当に削除しますか？</p>
+          <div className="mt-8 py-3">
+            <Button
+              type="button"
+              click={() => setIsModalOpen(false)}
+              addStyle="btn-primary w-32 h-14 mr-10"
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" click={handleDelete} addStyle="btn-secondary h-14 w-32">
+              削除
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)及びお世話の記録ページ(`/care-record-calendar`)について、データを削除する際に確認用のモーダルを追加しました。


### 修正前：
- 削除ボタンを押すと、すぐに削除される。

### 修正後：
- 両ページで削除ボタンを押すと、本当に削除するか確認用のモーダルが表示される。
- モーダル上で「削除」ボタンを押すと削除が実行され、「キャンセル」ボタンを押すとモーダルが閉じる。

### 修正理由：
- 誤った操作による削除を防ぐことで、UXを向上させるため。

## 実装概要
- 削除確認用のモーダルを追加 `3fa06fb`
- キャンセルボタンの色をグレーに修正 `fab743d`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |  ![スクリーンショット 2023-10-10 17 17 00](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/1ee55751-44a1-446e-99ee-0904ea31c471) |


# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
