### PR TITLE
メモの高さが背景色の高さを超えた場合にスクロールするよう修正

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -561,7 +561,7 @@ export const CareRecordCalendarPage = () => {
                   />
                   <p className=" text-left text-base text-dark-black">メモ</p>
                 </div>
-                <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
+                <div className="h-96 w-[500px] overflow-y-auto rounded-xl bg-ligth-white p-5">
                   <p className="whitespace-pre-wrap text-left text-base text-dark-black">
                     {careMemo}
                   </p>

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -347,7 +347,7 @@ export const ChinchillaProfilePage = () => {
                 />
                 <p className=" text-left text-base text-dark-black">メモ</p>
               </div>
-              <div className=" h-96 w-[500px] rounded-xl bg-ligth-white p-5">
+              <div className="h-96 w-[500px] overflow-y-auto rounded-xl bg-ligth-white p-5">
                 <p className="whitespace-pre-wrap text-left text-base text-dark-black">
                   {selectedChinchilla.chinchillaMemo}
                 </p>


### PR DESCRIPTION
# 説明
以下のとおりチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)及びお世話の記録ページ(`/care-record-calendar`)について、メモの高さが背景色の高さを超えた場合にスクロールするよう修正しました。


### 修正前：
- メモの高さが背景色の高さを超えると、入力内容が背景色からはみ出る。

### 修正後：
-  メモの高さが背景色の高さを超えた場合にスクロールするよう修正しました。

### 修正理由：
- UI/UXの改善のため。

## 実装概要
- メモの高さが背景色の高さを超えた場合にスクロールするよう修正 `ec0dfa6`



# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-10-12 11 28 49](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/036abc1b-477c-4a26-bb9b-6ab0e6468a2e) |  ![スクリーンショット 2023-10-12 11 29 18](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/21d6acb4-17b1-43bd-8cfd-357fe90d76d0) |

# 変更のタイプ
- [ ] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
