### PR TITLE
お世話の記録が表示されない問題及びchinchillasテーブルに関するAPIの修正

### DIFF
--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -9,6 +9,13 @@ class Api::V1::ChinchillasController < ApplicationController
     render json: chinchillas.as_json(only: [:id, :chinchilla_name, :chinchilla_image])
   end
 
+  # チンチラの選択セレクトボックス用
+  def my_chinchillas_names
+    user_id = current_api_v1_user.id
+    chinchillas = Chinchilla.where(user_id: user_id)
+    render json: chinchillas.as_json(only: [:id, :chinchilla_name])
+  end
+
   # チンチラ個別プロフィール
   def show
     chinchilla = Chinchilla.find(params[:id])

--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -2,11 +2,11 @@ class Api::V1::ChinchillasController < ApplicationController
   # ログイン状態の確認
   before_action :authenticate_api_v1_user!
 
-  # チンチラプロフィール 一覧
-  def index
+  # マイチンチラ用
+  def my_chinchillas
     user_id = current_api_v1_user.id
     chinchillas = Chinchilla.where(user_id: user_id)
-    render json: chinchillas
+    render json: chinchillas.as_json(only: [:id, :chinchilla_name, :chinchilla_image])
   end
 
   # チンチラ個別プロフィール

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
       # マイチンチラ用
       get '/my_chinchillas', to: 'chinchillas#my_chinchillas'
+      # チンチラの選択セレクトボックス用
+      get '/my_chinchillas_names', to: 'chinchillas#my_chinchillas_names'
       # チンチラ個別プロフィール
       get '/chinchillas/:id', to: 'chinchillas#show'
       # チンチラプロフィール作成

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
         resources :sessions, only: %i[index]
       end
 
-      # チンチラプロフィール一覧
-      get '/chinchillas', to: 'chinchillas#index'
+      # マイチンチラ用
+      get '/my_chinchillas', to: 'chinchillas#my_chinchillas'
       # チンチラ個別プロフィール
       get '/chinchillas/:id', to: 'chinchillas#show'
       # チンチラプロフィール作成

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -47,9 +47,21 @@ export const CareRecordCalendarPage = () => {
 
   // 全てのチンチラのデータを取得
   const fetch = async () => {
-    const res = await getAllChinchillas()
-    console.log(res.data)
-    setAllChinchillas(res.data)
+    try {
+      const res = await getAllChinchillas()
+      console.log('チンチラ一覧', res.data)
+      setAllChinchillas(res.data)
+
+      // チンチラを選択中の場合に、お世話の記録を取得
+      if (chinchillaId) {
+        const res = await getAllCares(chinchillaId)
+        console.log('お世話記録一覧：', res.data)
+        setAllCares(res.data)
+      }
+    } catch (err) {
+      console.log(err)
+      alert('エラーです')
+    }
   }
 
   // 初回レンダリング時に全てのチンチラのデータを取得

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react'
-import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { getMyChinchillasNames } from 'src/lib/api/chinchilla'
 import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
@@ -48,7 +48,7 @@ export const CareRecordCalendarPage = () => {
   // 全てのチンチラのデータを取得
   const fetch = async () => {
     try {
-      const res = await getAllChinchillas()
+      const res = await getMyChinchillasNames()
       console.log('チンチラ一覧', res.data)
       setAllChinchillas(res.data)
 

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useContext } from 'react'
 import Link from 'next/link'
-import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { getMyChinchillas } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -11,8 +11,8 @@ export const MyChinchillaPage = () => {
   const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   const fetch = async () => {
-    const res = await getAllChinchillas()
-    console.log(res.data)
+    const res = await getMyChinchillas()
+    console.log('マイチンチラ', res.data)
     setAllChinchillas(res.data)
   }
 

--- a/frontend/src/components/pages/weight-chart/index.jsx
+++ b/frontend/src/components/pages/weight-chart/index.jsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic'
 import { useState, useEffect, useContext } from 'react'
-import { getAllChinchillas } from 'src/lib/api/chinchilla'
+import { getMyChinchillasNames } from 'src/lib/api/chinchilla'
 import { getWeightCares } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
@@ -21,7 +21,7 @@ export const WeightChartPage = () => {
   // 全てのチンチラのデータを取得
   const fetch = async () => {
     try {
-      const res = await getAllChinchillas()
+      const res = await getMyChinchillasNames()
       console.log('チンチラ一覧', res.data)
       setAllChinchillas(res.data)
 

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -15,10 +15,10 @@ export const getMyChinchillas = () => {
   })
 }
 
-// チンチラの選択セレクトボックス用
-export const getAllChinchillas = () => {
+// チンチラの選択セレクトボックス用 id, chinchillaNameを取得
+export const getMyChinchillasNames = () => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.get('/chinchillas', {
+  return client.get('/my_chinchillas_names', {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -3,7 +3,19 @@ import { client } from 'src/lib/api/client'
 
 // 機能&リクエストURL
 
-// チンチラプロフィール一覧(全部)
+// マイチンチラページ用 id, chinchillaName, chinchillaImageを取得
+export const getMyChinchillas = () => {
+  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
+  return client.get('/my_chinchillas', {
+    headers: {
+      'access-token': Cookies.get('_access_token'),
+      client: Cookies.get('_client'),
+      uid: Cookies.get('_uid')
+    }
+  })
+}
+
+// チンチラの選択セレクトボックス用
 export const getAllChinchillas = () => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.get('/chinchillas', {
@@ -15,7 +27,7 @@ export const getAllChinchillas = () => {
   })
 }
 
-// チンチラプロフィール一覧(個別)
+// チンチラプロフィール用
 export const getChinchilla = (chinchillaId) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.get(`/chinchillas/${chinchillaId}`, {


### PR DESCRIPTION
# 説明
以下のとおり別のページでチンチラを選択している状態でお世話の記録ページ(`/care-record-calendar`)を表示すると、お世話の記録が表示されない問題等を修正しました。


### 修正前：
- 別のページでチンチラを選択している状態で、お世話の記録ページ(`/care-record-calendar`)を表示すると、セレクトボックスでは選択中になっているが、お世話の記録は表示されない。
- チンチラの特定のデータのみ使用するページにおいて、不要なデータを含めてDBのデータを全件取得している。

### 修正後：
- 初回レンダリング時でも選択中のチンチラに関するお世話の記録を表示するよう修正しました。
- ページごとに必要なデータのみ取得するようAPIを修正しました。

### 修正理由：
- 見た目上との齟齬や不要な操作を減らし、UI/UXを向上させるため。
- データ取得の際のパフォーマンスを向上させるため。

## 実装概要
- 別のページでチンチラを選択している場合も初回レンダリング時にお世話の表示するよう修正 `a84a443`
- chinchillasテーブルに関するAPIの修正 `5a4ce84` `7b590d0`

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] バグフィックス
- [ ] リファクタリング
- [x] 仕様変更
