### PR TITLE
ログイン状態によってアクセスできるページを制限する機能を追加

### DIFF
--- a/frontend/src/components/pages/signin/index.jsx
+++ b/frontend/src/components/pages/signin/index.jsx
@@ -43,7 +43,7 @@ export const SignInPage = () => {
         setIsSignedIn(true)
         setCurrentUser(res.data.data)
 
-        router.push('/mypage')
+        router.push('/mychinchilla')
         console.log('ログイン成功！')
       } else {
         alert('ログイン失敗')

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -43,7 +43,7 @@ export const SignUpPage = () => {
         setIsSignedIn(true)
         setCurrentUser(res.data.data)
 
-        router.push('/mypage')
+        router.push('/mychinchilla')
         console.log('新規登録成功！')
       } else {
         alert('新規登録失敗')

--- a/frontend/src/lib/api/client.js
+++ b/frontend/src/lib/api/client.js
@@ -12,7 +12,7 @@ export const client = applyCaseMiddleware(
   axios.create({
     //Cookieを利用
     withCredentials: true,
-    baseURL: process.env.NEXT_PUBLIC_APP_API_DOMEIN
+    baseURL: process.env.NEXT_PUBLIC_APP_API_DOMAIN
   }),
   options
 )

--- a/frontend/src/middleware.js
+++ b/frontend/src/middleware.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server'
+
+export async function middleware(request) {
+  const accessToken = request.cookies.get('_access_token')?.value
+  const client = request.cookies.get('_client')?.value
+  const uid = request.cookies.get('_uid')?.value
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_APP_API_DOMAIN}/auth/sessions`, {
+    credentials: 'include',
+    headers: {
+      'access-token': accessToken,
+      client: client,
+      uid: uid
+    }
+  })
+
+  const data = await res.json()
+
+  // 未ログイン時のリダイレクト対象ページ
+  const redirectIfNotLoggedInPaths = [
+    '/mypage',
+    '/mychinchilla', // チンチラプロフィールも含む
+    '/care-record-calendar',
+    '/chinchilla-registration',
+    '/weight-chart'
+  ]
+
+  // ログイン時のリダイレクト対象ページ
+  const redirectIfLoggedInPaths = ['/signin', '/signup']
+
+  if (
+    data.is_login === false &&
+    redirectIfNotLoggedInPaths.some((path) => request.nextUrl.pathname.startsWith(path))
+  ) {
+    return NextResponse.redirect(new URL('/signin', request.url))
+  }
+
+  if (
+    data.is_login === true &&
+    redirectIfLoggedInPaths.some((path) => request.nextUrl.pathname.startsWith(path))
+  ) {
+    return NextResponse.redirect(new URL('/mychinchilla', request.url))
+  }
+
+  return NextResponse.next()
+}


### PR DESCRIPTION
# 説明
以下のとおりNext.jsのmiddlewareを利用し、ログイン状態によってアクセスできるページを制限する機能（アクセスコントロール）を追加しました。


### 修正前：
- ログイン状態に関係なく、全てのページにアクセス可能。

### 修正後：
- 未ログイン時に以下のページにアクセスした場合は、ログインページ(`/signin`)にリダイレクトするようにしました。
  - マイページ(`/mypage`)
  - チンチラ登録ページ(`/chinchilla-registration`)
  - マイチンチラページ(`/mychinchilla`)
  - チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)
  - お世話の記録ページ(`/care-record-calendar`)
  - 体重ページ(`/weight-chart`)

- ログイン時に以下のページにアクセスした場合は、マイチンチラページ(`/mychinchilla`)にリダイレクトするようにしました。
  - 新規登録ページ(`/signup`)
  - ログインページ(`/signin`)

### 修正理由：
- セキュリティ及びUXの向上のため。

## 実装概要
- ログイン状態によってアクセスできるページを制限する機能を追加 `7e0e13f`
- リダイレクト先の修正等 `aa6f59f` `bf063b8`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [ ] バグフィックス
- [ ] リファクタリング
- [ ] 仕様変更
