### PR TITLE
複数の修正

### DIFF
--- a/frontend/src/components/pages/chinchilla-registration/index.jsx
+++ b/frontend/src/components/pages/chinchilla-registration/index.jsx
@@ -1,6 +1,7 @@
-import { useRef, useCallback, useState } from 'react'
+import { useContext, useRef, useCallback, useState } from 'react'
 import { useRouter } from 'next/router'
 import { createChinchilla } from 'src/lib/api/chinchilla'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -12,6 +13,10 @@ import { faAsterisk, faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 
 export const ChinchillaRegistrationPage = () => {
   const router = useRouter()
+
+  // 選択中のチンチラの状態管理（グローバル）
+  const { setChinchillaId, setHeaderName, setHeaderImage } = useContext(SelectedChinchillaIdContext)
+
   const [chinchillaImage, setChinchillaImage] = useState('')
   const chinchillaMemo = ''
 
@@ -78,6 +83,9 @@ export const ChinchillaRegistrationPage = () => {
 
       // ステータス201 Created
       if (res.status === 201) {
+        setChinchillaId(res.data.id)
+        setHeaderName(res.data.chinchillaName)
+        setHeaderImage(res.data.chinchillaImage)
         router.push('/mychinchilla')
         console.log('チンチラプロフィール作成成功！')
       } else {

--- a/frontend/src/components/pages/chinchilla-registration/index.jsx
+++ b/frontend/src/components/pages/chinchilla-registration/index.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { useContext, useRef, useCallback, useState } from 'react'
 import { useRouter } from 'next/router'
 import { createChinchilla } from 'src/lib/api/chinchilla'
@@ -156,18 +157,26 @@ export const ChinchillaRegistrationPage = () => {
               必須入力
             </span>
           </label>
-          <select
-            id="chinchillaSex"
-            {...register('chinchillaSex')}
-            className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-          >
-            <option hidden value="">
-              選択してください
-            </option>
-            <option value="オス">オス</option>
-            <option value="メス">メス</option>
-            <option value="不明">不明</option>
-          </select>
+          <div className="flex h-12 w-full justify-around rounded-lg border border-solid border-dark-blue bg-ligth-white px-1">
+            {['オス', 'メス', '不明'].map((sex) => (
+              <React.Fragment key={sex}>
+                <label
+                  htmlFor={sex}
+                  className="flex cursor-pointer items-center text-base text-dark-black"
+                >
+                  {sex}
+                  <input
+                    id={sex}
+                    type="radio"
+                    name="chinchillaSex"
+                    value={sex}
+                    {...register('chinchillaSex')}
+                    className="radio-accent radio ml-2"
+                  />
+                </label>
+              </React.Fragment>
+            ))}
+          </div>
           {errors.chinchillaSex && (
             <p className="label text-base text-dark-pink">{errors.chinchillaSex.message}</p>
           )}

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { useRef, useCallback, useEffect, useState, useContext } from 'react'
 import { useRouter } from 'next/router'
 import { getChinchilla, updateChinchilla, deleteChinchilla } from 'src/lib/api/chinchilla'
@@ -241,18 +242,26 @@ export const ChinchillaProfilePage = () => {
                   必須入力
                 </span>
               </label>
-              <select
-                id="chinchillaSex"
-                {...register('chinchillaSex')}
-                className="w-ful select select-bordered select-primary border-dark-blue bg-ligth-white text-base font-light text-dark-black"
-              >
-                <option hidden value="">
-                  選択してください
-                </option>
-                <option value="オス">オス</option>
-                <option value="メス">メス</option>
-                <option value="不明">不明</option>
-              </select>
+              <div className="flex h-12 w-full justify-around rounded-lg border border-solid border-dark-blue bg-ligth-white px-1">
+                {['オス', 'メス', '不明'].map((sex) => (
+                  <React.Fragment key={sex}>
+                    <label
+                      htmlFor={sex}
+                      className="flex cursor-pointer items-center text-base text-dark-black"
+                    >
+                      {sex}
+                      <input
+                        id={sex}
+                        type="radio"
+                        name="chinchillaSex"
+                        value={sex}
+                        {...register('chinchillaSex')}
+                        className="radio-accent radio ml-2"
+                      />
+                    </label>
+                  </React.Fragment>
+                ))}
+              </div>
               {errors.chinchillaSex && (
                 <p className="label text-base text-dark-pink">{errors.chinchillaSex.message}</p>
               )}

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -29,7 +29,13 @@ export const MyChinchillaPage = () => {
       <h1 className="text-center text-2xl font-bold tracking-widest text-dark-blue">
         マイチンチラ
       </h1>
-      <div className="mt-6 grid grid-cols-2 gap-x-20 gap-y-14">
+      <div
+        className={`mt-6 grid ${
+          allChinchillas.length === 1
+            ? 'grid-cols-1 place-items-center'
+            : 'grid-cols-2 gap-x-20 gap-y-14'
+        }`}
+      >
         {allChinchillas.map((chinchilla) => (
           <div key={chinchilla.id}>
             <Link
@@ -49,7 +55,9 @@ export const MyChinchillaPage = () => {
                   alt="プロフィール画像"
                   className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
                 />
-                <p className="w-[200px] text-center">{chinchilla.chinchillaName}</p>
+                <p className="w-[200px] text-center text-base text-dark-black">
+                  {chinchilla.chinchillaName}
+                </p>
               </div>
             </Link>
           </div>

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -11,9 +11,13 @@ export const MyChinchillaPage = () => {
   const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   const fetch = async () => {
-    const res = await getMyChinchillas()
-    console.log('マイチンチラ', res.data)
-    setAllChinchillas(res.data)
+    try {
+      const res = await getMyChinchillas()
+      console.log('マイチンチラ', res.data)
+      setAllChinchillas(res.data)
+    } catch (err) {
+      console.log(err)
+    }
   }
 
   useEffect(() => {

--- a/frontend/src/components/pages/mypage/index.jsx
+++ b/frontend/src/components/pages/mypage/index.jsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Cookies from 'js-cookie'
 import { signOut } from 'src/lib/api/auth'
 import { AuthContext } from 'src/contexts/auth'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { Button } from 'src/components/shared/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -11,7 +12,8 @@ import { faKey, faAngleRight, faEnvelope, faTrashCan } from '@fortawesome/free-s
 
 export const MyPagePage = () => {
   const router = useRouter()
-  const { setIsSignedIn } = useContext(AuthContext)
+  const { setIsSignedIn, setCurrentUser, setProcessUser } = useContext(AuthContext)
+  const { setChinchillaId, setHeaderName, setHeaderImage } = useContext(SelectedChinchillaIdContext)
 
   // ログアウト機能
   const handleSignOut = async () => {
@@ -26,6 +28,11 @@ export const MyPagePage = () => {
 
         router.push('/signin')
         setIsSignedIn(false)
+        setCurrentUser(null)
+        setProcessUser(null)
+        setChinchillaId(0)
+        setHeaderName('')
+        setHeaderImage('')
         console.log('ログアウトしました！')
       } else {
         alert('ログアウト失敗')

--- a/frontend/src/components/pages/weight-chart/index.jsx
+++ b/frontend/src/components/pages/weight-chart/index.jsx
@@ -193,7 +193,9 @@ export const WeightChartPage = () => {
       <h1 className="text-center text-2xl font-bold tracking-widest text-dark-blue">体重</h1>
 
       {/* グラフ */}
-      <DynamicWeightChart filteredData={filteredData} />
+      <div className="mt-6 h-[400px]">
+        <DynamicWeightChart filteredData={filteredData} />
+      </div>
 
       {/* 表示範囲のラジオボタン */}
       <div className="join mt-10">

--- a/frontend/src/components/pages/weight-chart/index.jsx
+++ b/frontend/src/components/pages/weight-chart/index.jsx
@@ -6,7 +6,7 @@ import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 import { utcToZonedTime } from 'date-fns-tz'
 
 export const WeightChartPage = () => {
-  // CSRとSSR間のレンダリングエラー回避
+  // ハイドレーションエラー回避
   const DynamicWeightChart = dynamic(
     () =>
       import('src/components/pages/weight-chart/weightChart').then((module) => module.WeightChart),

--- a/frontend/src/components/pages/weight-chart/weightChart.jsx
+++ b/frontend/src/components/pages/weight-chart/weightChart.jsx
@@ -21,7 +21,7 @@ export const WeightChart = ({ filteredData }) => {
       height={400}
       data={filteredData}
       margin={{ top: 30, right: 40, bottom: 20, left: 10 }}
-      className="mt-6 rounded-xl bg-ligth-white"
+      className="rounded-xl bg-ligth-white"
     >
       <Line type="monotone" dataKey="careWeight" stroke="#F2B3B3" strokeWidth={2} unit="g" />
       <CartesianGrid stroke="#ccc" strokeDasharray="3 3" />

--- a/frontend/src/components/shared/Footer.jsx
+++ b/frontend/src/components/shared/Footer.jsx
@@ -13,13 +13,22 @@ export const Footer = () => {
         {isSignedIn && currentUser ? (
           <div>
             <Link href="/mychinchilla">
-              <FontAwesomeIcon icon={faHouse} className="mx-12 text-4xl text-ligth-white" />
+              <FontAwesomeIcon
+                icon={faHouse}
+                className="mx-12 text-4xl text-ligth-white transition-colors duration-200 hover:text-slate-200"
+              />
             </Link>
             <Link href="/care-record-calendar">
-              <FontAwesomeIcon icon={faCalendarDays} className="mx-12 text-4xl text-ligth-white" />
+              <FontAwesomeIcon
+                icon={faCalendarDays}
+                className="mx-12 text-4xl text-ligth-white transition-colors duration-200 hover:text-slate-200"
+              />
             </Link>
             <Link href="/weight-chart">
-              <FontAwesomeIcon icon={faChartLine} className="mx-12 text-4xl text-ligth-white" />
+              <FontAwesomeIcon
+                icon={faChartLine}
+                className="mx-12 text-4xl text-ligth-white transition-colors duration-200 hover:text-slate-200"
+              />
             </Link>
           </div>
         ) : (

--- a/frontend/src/components/shared/Header.jsx
+++ b/frontend/src/components/shared/Header.jsx
@@ -97,7 +97,7 @@ export const Header = () => {
                   className="mr-2 h-10 w-10 rounded-[50%] border border-solid border-ligth-white bg-ligth-white"
                 />
               )}
-              <p className="text-base text-ligth-white">
+              <p className="text-base text-ligth-white transition-colors duration-200 hover:text-slate-200">
                 {headerName ? headerName : 'チンチラを選択'}
               </p>
               {!headerName && (
@@ -142,7 +142,10 @@ export const Header = () => {
               </div>
             )}
             <Link href="/mypage">
-              <FontAwesomeIcon icon={faCircleUser} className="mr-32 text-4xl text-ligth-white" />
+              <FontAwesomeIcon
+                icon={faCircleUser}
+                className="mr-32 text-4xl text-ligth-white transition-colors duration-200 hover:text-slate-200"
+              />
             </Link>
           </>
         ) : (

--- a/frontend/src/components/shared/Header.jsx
+++ b/frontend/src/components/shared/Header.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useState, useEffect } from 'react'
 import Link from 'next/link'
 import { AuthContext } from 'src/contexts/auth'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
@@ -47,6 +47,27 @@ export const Header = () => {
     setHeaderImage(selectedChinchilla[0].chinchillaImage)
     setIsModalOpen(false)
   }
+
+  // チンチラが登録されている場合は、先頭のチンチラをセット
+  const fetch = async () => {
+    if (currentUser) {
+      try {
+        const res = await getMyChinchillas()
+        if (res.data.length !== 0) {
+          setChinchillaId(res.data[0].id)
+          setHeaderName(res.data[0].chinchillaName)
+          setHeaderImage(res.data[0].chinchillaImage)
+        }
+      } catch (err) {
+        console.log(err)
+      }
+    }
+  }
+
+  // ログイン時に先頭のチンチラをセット
+  useEffect(() => {
+    fetch()
+  }, [currentUser])
 
   return (
     <header className="fixed top-0 z-50 h-16 w-full bg-dark-blue">

--- a/frontend/src/contexts/auth.js
+++ b/frontend/src/contexts/auth.js
@@ -7,8 +7,8 @@ export const AuthContext = createContext({})
 //_app.jsにエクスポートして、全体の親にする
 export const AuthProvider = ({ children }) => {
   const [isSignedIn, setIsSignedIn] = useState(false)
-  const [currentUser, setCurrentUser] = useState()
-  const [processUser, setProcessUser] = useState()
+  const [currentUser, setCurrentUser] = useState(undefined)
+  const [processUser, setProcessUser] = useState(undefined)
   const value = {
     isSignedIn,
     setIsSignedIn,
@@ -28,7 +28,7 @@ export const AuthProvider = ({ children }) => {
         setIsSignedIn(true)
         setCurrentUser(res?.data.data)
 
-        console.log(res?.data.data)
+        console.log('ログイン中:', res?.data.data)
       } else {
         console.log('No current user')
       }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -56,13 +56,14 @@ module.exports = {
           // ピンク系
           secondary: '#F2B3B3',
           'secondary-dark': '#E67A7A',
-          // 白系
-          accent: '#FFFFFF',
-          // %どうしよ・・・
-          'accent-dark': '#FFFFFF',
+
+          accent: '#7EC2C2',
+          success: '#E67A7A',
+
           // 黒系
           neutral: '#4B4B4B',
           'neutral-light': '#D7D7D7',
+
           // 背景色
           'base-100': '#FFF4E1'
           // info: '#3abff8',


### PR DESCRIPTION
# 説明
以下のとおり修正を行いました。


### 修正前：
1. 体重ページ(`/weight-chart`)において、後からレンダリングされるグラフを表示する余白が確保されていない。
2. ログインする度に毎回ヘッダーからチンチラを選択する必要がある。
3. マイチンチラページ(`/mychinchilla`)において、1匹しか登録していない場合も、2x2のgridの左上に表示される。
4. チンチラ登録ページ(`/chinchilla-registration`)及びチンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)において、セレクトボックスから性別を選択する必要がある。
5. ヘッダー・フッターにおいて、アイコンにカーソルが当たった時に変化がない。

### 修正後：
1. グラフの高さを予め確保するよう修正しました。
2. 初回は先頭のチンチラを選択中にするよう修正しました。
3. 1匹しか登録していない場合は、真ん中の上に表示するよう修正しました。
4. セレクトボックスをラジオボタンに変更しました。
5. hoverした時にアイコンの色が変化するように修正しました。

### 修正理由：
- UI/UXの向上のため。

## 実装概要
- グラフの高さを確保するよう修正 `087f0a8`
- 初回は先頭のチンチラをセットするよう修正 `6923067`
- 1匹しか登録していない場合は真ん中に表示するよう修正 `aea89df`
- 性別の選択をセレクトボックスからラジオボタンに修正 `2919901`
- hoverした時にアイコンの色が変化するように修正 `48434ba`
- コメントの修正 `85ea0cf`


# スクリーンショット
3. 1匹登録時のマイチンチラページ(`/mychinchilla`)

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-11-12 11 38 04](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/8abe0e51-9e5c-4436-ac03-a118e34afe2b) | ![スクリーンショット 2023-11-12 11 38 21](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/854ea350-2337-46cf-8913-d531fb7136d7) |

5. 性別の選択フォーム

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-11-12 11 35 23](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/5f4ed1d9-cf04-4572-9bab-275f8a484304) | ![スクリーンショット 2023-11-12 11 34 54](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/c42db134-94b1-4d7a-a06a-a092bcee653f)  |



# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [x] デザイン・UI/UX
- [ ] リファクタリング

