### PR TITLE
体重検索用のインデックスを追加

### DIFF
--- a/backend/db/migrate/20231112082210_add_index_to_cares.rb
+++ b/backend/db/migrate/20231112082210_add_index_to_cares.rb
@@ -1,0 +1,5 @@
+class AddIndexToCares < ActiveRecord::Migration[7.0]
+  def change
+    add_index :cares, [:chinchilla_id, :care_day], name: 'index_cares_on_chinchilla_id_and_care_day'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_16_072945) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_12_082210) do
   create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "care_day", null: false
     t.string "care_food"
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_072945) do
     t.bigint "chinchilla_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["chinchilla_id", "care_day"], name: "index_cares_on_chinchilla_id_and_care_day"
     t.index ["chinchilla_id"], name: "index_cares_on_chinchilla_id"
   end
 


### PR DESCRIPTION
# 説明
以下のとおり、体重ページ(`/weight-chart`)で選択中のチンチラの体重を日付順に全件取得するためのインデックスを作成しました。


### 修正前：
- 体重を全件取得する際にはchinchilla_idを使って検索している。

### 修正後：
- chinchilla_idとcare_dayを使って検索するようインデックスを追加しました。

### 修正理由：
- バックエンドAPIのパフォーマンス向上のため。

## 実装概要
- 選択中のチンチラの体重を日付順に全件取得するためのインデックスを追加 `e3990c6`


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
