### PR TITLE
バックエンドをAWSにデプロイするための修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,9 @@ FROM ruby:3.2.2-alpine
 ENV LANG=C.UTF-8
 ENV TZ=Asia/Tokyo
 
+# ローカルで使用する時はコメントアウトする
+ENV RAILS_ENV=production
+
 RUN apk update && \
   apk upgrade && \
   apk add --no-cache \
@@ -48,4 +51,4 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3010
 
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,21 +1,49 @@
-FROM ruby:3.2.2
+# ビルドステージ
+FROM ruby:3.2.2-alpine AS builder
 
+ENV LANG=C.UTF-8
+ENV TZ=Asia/Tokyo
 ENV BUNDLER_VERSION=2.4.17
+
+RUN apk update && \
+  apk upgrade && \
+  apk add --virtual build-packs --no-cache \
+  alpine-sdk \
+  build-base \
+  curl-dev \
+  mysql-dev \
+  tzdata && \
+  mkdir /backend
+
+WORKDIR /backend
+
+COPY Gemfile Gemfile.lock /backend/
+
+RUN gem install bundler -v $BUNDLER_VERSION
+RUN bundle install --jobs=4
+RUN apk del build-packs
+
+
+# 実行ステージ
+FROM ruby:3.2.2-alpine
+
 ENV LANG=C.UTF-8
 ENV TZ=Asia/Tokyo
 
-RUN mkdir /backend
+RUN apk update && \
+  apk upgrade && \
+  apk add --no-cache \
+  bash \
+  mysql-dev \
+  tzdata && \
+  mkdir /backend
+
 WORKDIR /backend
 
-COPY Gemfile /backend/Gemfile
-COPY Gemfile.lock /backend/Gemfile.lock
-
-RUN gem install bundler -v $BUNDLER_VERSION
-RUN bundle -v
-RUN bundle install --jobs=4
-
+COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY . /backend
 COPY entrypoint.sh /usr/bin/
+
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3010

--- a/backend/app/controllers/api/v1/tests_controller.rb
+++ b/backend/app/controllers/api/v1/tests_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::TestsController < ApplicationController
+  def index
+    render json: { message: 'Hello, world!!' }
+  end
+end

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -13,14 +13,17 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
-  host: db # Docker用
-  # host: localhost # ローカル用
+  # username: root
+  # password:
+  # host: localhost
 
 development:
   <<: *default
   database: backend_development
+  username: root
+  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+  host: db # Docker用
+  # host: localhost # ローカル用
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -28,6 +31,10 @@ development:
 test:
   <<: *default
   database: backend_test
+  username: root
+  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+  host: db # Docker用
+  # host: localhost # ローカル用
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -51,6 +58,8 @@ test:
 #
 production:
   <<: *default
-  database: backend_production
-  username: backend
-  password: <%= ENV["BACKEND_DATABASE_PASSWORD"] %>
+  database: <%= ENV["DB_DATABASE"] %>
+  username: <%= ENV["DB_USERNAME"] %>
+  password: <%= ENV["DB_PASSWORD"] %>
+  host: <%= ENV["DB_HOST"] %>
+  port: <%= ENV["DB_PORT"] %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
       # お世話記録 削除
       delete '/cares/:id', to: 'cares#destroy'
 
+      # テスト用
+      get '/test', to: 'tests#index'
+
     end
   end
 end

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,9 +4,19 @@ set -e
 # Rails特有の問題を解決するためのコマンド
 rm -f /backend/tmp/pids/server.pid
 
-# ローカル環境用
-# 初回コンテナ起動時のマイグレーションエラーを回避するため
-rails db:migrate RAILS_ENV=development
+if [ "$RAILS_ENV" = "production" ]; then
+  # 本番環境用
+  # 本番環境（AWS ECS）への初回デプロイ時に利用
+  # 初回デプロイ後にコメントアウトする
+  # bundle exec rails db:create
+  # --------------------------------------
+  bundle exec rails db:migrate
+else
+  # ローカル環境用
+  # 初回コンテナ起動時のマイグレーションエラーを回避するため
+  # 初回コンテナ起動後にコメントアウトする
+  bundle exec rails db:migrate
+fi
 
 # サーバー実行(DockerfileのCMDをセット)
 exec "$@"

--- a/backend/test/controllers/api/v1/tests_controller_test.rb
+++ b/backend/test/controllers/api/v1/tests_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::TestsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 説明
以下のとおりバックエンドをAWSにデプロイするために修正を行いました。


### 修正前：
- テスト用のAPIを作成していない。
- Dockerfileのイメージサイズが446MB。
- database.yml等において、本番環境用の設定等が記述されていない。

### 修正後：
- ALB-ECS間のヘルスチェックに利用するテスト用のAPIを作成しました。
- Alpine LinuxベースのRubyイメージに変更し、Dockerfileのイメージサイズを110MBに削減しました。
- 本番環境用にdatabase.yml等のコードや設定を修正しました。

### 修正理由：
- ECS上でコンテナを起動する際にヘルスチェックを行う必要があるため。
- ECR上でDockerfileのイメージを管理する際に、ストレージを圧迫するため。また、デプロイにかかる時間を短縮するため。
- バックエンドをAWSにデプロイするため。

## 実装概要
- ALB-ECS間のヘルスチェックに利用するテスト用のAPIを作成 5186c4b
- Dockerfileのイメージサイズを軽量化 d2c9c82
- 本番環境用にdatabase.yml等のコードや設定を修正 653dc92

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
