### PR TITLE
本番環境におけるCORS及びDevise/Devise token authによる認証メールに関するエラーの修正

### DIFF
--- a/backend/app/controllers/api/v1/auth/confirmations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/confirmations_controller.rb
@@ -1,0 +1,32 @@
+# ActionController::Redirecting::UnsafeRedirectError: Unsafe redirect toのエラー対応
+class Api::V1::Auth::ConfirmationsController < DeviseTokenAuth::ConfirmationsController
+  def show
+    @resource = resource_class.confirm_by_token(resource_params[:confirmation_token])
+
+    if @resource.errors.empty?
+      yield @resource if block_given?
+
+      redirect_header_options = { account_confirmation_success: true }
+
+      if signed_in?(resource_name)
+        token = signed_in_resource.create_token
+        signed_in_resource.save!
+
+        redirect_headers = build_redirect_headers(token.token,
+                                                  token.client,
+                                                  redirect_header_options)
+
+        redirect_to_link = signed_in_resource.build_auth_url(redirect_url, redirect_headers)
+      else
+        redirect_to_link = DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
+      end
+
+      # allow_other_host: trueを追加することで、外部URLへのリダイレクトを許容する
+      redirect_to(redirect_to_link, allow_other_host: true)
+    elsif redirect_url
+      redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false), allow_other_host: true
+    else
+      raise ActionController::RoutingError, 'Not Found'
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,3 +1,41 @@
-# パスワードリセット用コントローラー
+# ActionController::Redirecting::UnsafeRedirectError: Unsafe redirect toのエラー対応
 class Api::V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
+  def edit
+    # if a user is not found, return nil
+    @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
+
+    if @resource && @resource.reset_password_period_valid?
+      token = @resource.create_token unless require_client_password_reset_token?
+
+      # ensure that user is confirmed
+      @resource.skip_confirmation! if confirmable_enabled? && !@resource.confirmed_at
+      # allow user to change password once without current_password
+      @resource.allow_password_change = true if recoverable_enabled?
+
+      @resource.save!
+
+      yield @resource if block_given?
+
+      # allow_other_host: trueを追加することで、外部URLへのリダイレクトを許容する
+      if require_client_password_reset_token?
+        redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token]),
+        allow_other_host: true
+      else
+        if DeviseTokenAuth.cookie_enabled
+          set_token_in_cookie(@resource, token)
+        end
+
+        redirect_header_options = { reset_password: true }
+        redirect_headers = build_redirect_headers(token.token,
+                                                  token.client,
+                                                  redirect_header_options)
+        redirect_to(@resource.build_auth_url(@redirect_url,
+                                              redirect_headers),
+                                              # allow_other_host: trueを追加することで、外部URLへのリダイレクトを許容する
+                                              allow_other_host: true)
+      end
+    else
+      render_edit_error
+    end
+  end
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -61,6 +61,20 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+# メール配信関係
+config.action_mailer.default_options = { from: ENV['EMAIL_ADDRESS'] }
+config.action_mailer.default_url_options = { host: ENV['API_DOMAIN'] }
+config.action_mailer.delivery_method = :smtp
+config.action_mailer.smtp_settings = {
+  address: 'smtp.gmail.com',
+  port: 587,
+  domain: 'gmail.com',
+  user_name: ENV['EMAIL_ADDRESS'],
+  password: ENV['EMAIL_PASSWORD'],
+  authentication: 'plain',
+  enable_starttls_auto: true
+}
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:3000"
+    if Rails.env.production?
+      origins 'https://www.chillalog.com'
+    else
+      origins 'http://localhost:3000'
+    end
 
     resource "*",
       headers: :any,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+
+      # devise_token_authのコントローラをオーバーライド
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations',
+        confirmations: 'api/v1/auth/confirmations',
         passwords: 'api/v1/auth/passwords',
       }
 


### PR DESCRIPTION
# 説明
以下のとおり本番環境において発生したCORS及びDevise/Devise token authによる認証メールに関するエラーを修正しました。

### 修正前：
- 本番環境においてフロントエンドとバックエンドの通信ができない。
- 本番環境用のメール配信設定がされていない。
- 本番環境でユーザーの新規登録、メールアドレス変更及びパスワードリセットを行う際のメール認証について、認証用のURLをクリックすると、ActionController::Redirecting::UnsafeRedirectErrorが発生する。

### 修正後：
- 本番環境の場合にフロントエンドのみ通信を許可するよう修正しました。
- 本番環境用にメール配信設定を行いました。
- Devise token authの新規登録、メールアドレス変更及びパスワードリセットに関するコントローラーを修正し、外部URLへのリダイレクトを許可するようにしました。

### 修正理由：
- 本番環境において想定した動作をしなかったため。

## 実装概要
- 本番環境におけるCORSエラーを修正 5e11734
- 本番環境用にメール配信設定を修正 ac3be5d
- 本番環境におけるメール認証で外部URLへのリダイレクトを許可するよう修正 7c883b1


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
