### PR TITLE
利用規約及びプライバシーポリシーの追加

### DIFF
--- a/frontend/src/components/pages/privacy-policy/index.jsx
+++ b/frontend/src/components/pages/privacy-policy/index.jsx
@@ -1,0 +1,78 @@
+import { PageTitle } from 'src/components/shared/PageTittle'
+import { Provision } from 'src/components/shared/Provision'
+
+export const PrivacyPolicyPage = () => {
+  return (
+    <div className="mx-auto my-28 grid max-w-screen-md place-content-center place-items-center gap-y-6 px-6">
+      <PageTitle pageTitle="プライバシーポリシー" />
+      <p className="text-justify text-base text-dark-black">
+        本ウェブサイト上で提供するサービス「ちらろぐ」（以下、「本サービス」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
+      </p>
+
+      <div className="w-full">
+        <Provision text="第1条（個人情報）" />
+        <p className="text-justify text-base text-dark-black">
+          「個人情報」とは、個人情報保護法にいう「個人情報」を指すものとし、特定の個人を識別できる情報（個人識別情報）を指します。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第2条（個人情報の収集方法）" />
+        <p className="text-justify text-base text-dark-black">
+          本サービスは、ユーザーが利用登録をする際に、メールアドレスを取得します。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第3条（個人情報を収集・利用する目的）" />
+        <p className="text-justify text-base text-dark-black">
+          本サービスが個人情報を収集・利用する目的は、以下のとおりです。
+        </p>
+        <ol className="list-inside list-decimal pt-3 text-justify text-base text-dark-black">
+          <li className="pb-1">本サービスの提供・運営のため</li>
+          <li className="pb-1">
+            ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
+          </li>
+          <li className="pb-1">メンテナンス、重要なお知らせなど必要に応じたご連絡のため</li>
+          <li className="pb-1">
+            利用規約に違反したユーザーや、不正・不当な目的でサービスを利用しようとするユーザーの特定をし、ご利用をお断りするため
+          </li>
+          <li className="pb-1">ユーザーにご自身の登録情報の閲覧や変更を行っていただくため</li>
+
+          <li className="pb-1">上記の利用目的に付随する目的</li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第4条（利用目的の変更）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスは、利用目的が変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
+          </li>
+          <li className="pb-1">
+            利用目的の変更を行った場合には、変更後の目的について、本サービス所定の方法により、ユーザーに通知、または本ウェブサイト上に公表するものとします。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第5条（個人情報の第三者提供）" />
+        <p className="text-justify text-base text-dark-black">
+          本サービスは、ユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。ただし、個人情報保護法その他の法令で認められる場合を除きます。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第6条（プライバシーポリシーの変更）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。
+          </li>
+          <li className="pb-1">
+            本サービスが別途定める場合を除いて、変更後のプライバシーポリシーは、本ウェブサイトに掲載したときから効力を生じるものとします。
+          </li>
+        </ol>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/signup/index.jsx
+++ b/frontend/src/components/pages/signup/index.jsx
@@ -63,6 +63,16 @@ export const SignUpPage = () => {
   return (
     <div className="mx-3 my-28 grid place-content-center place-items-center gap-y-6">
       <PageTitle pageTitle="新規登録" />
+      <h3 className="w-80 text-center text-base text-dark-black sm:w-96">
+        <Link href="/terms" className="link-hover link text-dark-blue">
+          利用規約
+        </Link>
+        および
+        <Link href="/privacy-policy" className="link-hover link text-dark-blue">
+          プライバシーポリシー
+        </Link>
+        に同意した上で、以下の「新規登録」ボタンを押してください。
+      </h3>
       <form
         noValidate
         onSubmit={handleSubmit(onSubmit)}

--- a/frontend/src/components/pages/terms/index.jsx
+++ b/frontend/src/components/pages/terms/index.jsx
@@ -1,0 +1,217 @@
+import { PageTitle } from 'src/components/shared/PageTittle'
+import { Provision } from 'src/components/shared/Provision'
+
+export const TermsPage = () => {
+  return (
+    <div className="mx-auto my-28 grid max-w-screen-md place-content-center place-items-center gap-y-6 px-6">
+      <PageTitle pageTitle="利用規約" />
+      <p className="text-justify text-base text-dark-black">
+        この利用規約（以下、「本規約」といいます。）は、このウェブサイト上で提供するサービス「ちらろぐ」（以下、「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。
+      </p>
+
+      <div className="w-full">
+        <Provision text="第1条（適用）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本規約は、ユーザーと本サービスの利用に関わる一切の関係に適用されるものとします。
+          </li>
+          <li className="pb-1">
+            本サービスに関し、本規約のほか、ご利用にあたってのルール等、各種の定め（以下、「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず、本規約の一部を構成するものとします。
+          </li>
+          <li className="pb-1">
+            本規約の規定が前条の個別規定の規定と矛盾する場合には、個別規定において特段の定めなき限り、個別規定の規定が優先されるものとします。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第2条（利用登録）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスにおいては、登録希望者が本規約に同意の上、本サービスの定める方法によって利用登録を申請し、本サービスがこれを承認することによって、利用登録が完了するものとします。
+          </li>
+          <li className="pb-1">
+            本サービスは、利用登録の申請者に以下の事由があると判断した場合、利用登録の申請を承認しないことがあり、その理由については一切の開示義務を負わないものとします。
+            <ul className="list-inside list-disc p-3">
+              <li>利用登録の申請に際して虚偽の事項を届け出た場合</li>
+              <li>本規約に違反したことがある者からの申請である場合</li>
+              <li>その他、本サービスが利用登録を相当でないと判断した場合</li>
+            </ul>
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第3条（ユーザーIDおよびパスワードの管理）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            ユーザーは、自己の責任において、本サービスのユーザーIDおよびパスワードを適切に管理するものとします。
+          </li>
+          <li className="pb-1">
+            ユーザーは、ユーザーIDおよびパスワードを第三者に譲渡または貸与、もしくは第三者と共用することはできません。本サービスは、ユーザーIDが登録情報と一致してログインされた場合には、そのユーザーIDを登録しているユーザー自身による利用とみなします。
+          </li>
+          <li className="pb-1">
+            ユーザーID及びパスワードが第三者によって使用されたことによって生じた損害は、本サービスは一切の責任を負わないものとします。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第4条（利用料金）" />
+        <p className="text-justify text-base text-dark-black">
+          ユーザーは、本サービスを無料で利用することができます。本サービスは、利用料金を請求することはありません。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第5条（禁止事項）" />
+        <p className="text-justify text-base text-dark-black">
+          ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
+        </p>
+        <ol className="list-inside list-decimal pt-3 text-justify text-base text-dark-black">
+          {/* 第1項-第5項 */}
+          <li className="pb-1">法令または公序良俗に違反する行為</li>
+          <li className="pb-1">犯罪行為に関連する行為</li>
+          <li className="pb-1">
+            本サービスの内容等、本サービスに含まれる著作権、商標権または知的財産権を侵害する行為
+          </li>
+          <li className="pb-1">
+            本サービス、他のユーザー、またはその他第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為
+          </li>
+          <li className="pb-1">本サービスによって得られた情報を商業的に利用する行為</li>
+
+          {/* 第6項-第10項 */}
+          <li className="pb-1">本サービスの運営を妨害するおそれのある行為</li>
+          <li className="pb-1">不正アクセス、またはこれを試みる行為</li>
+          <li className="pb-1">他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+          <li className="pb-1">不正な目的を持って本サービスを利用する行為</li>
+          <li className="pb-1">
+            本サービスの他のユーザーまたはその他の第三者に不利益、損害、不快感を与える行為
+          </li>
+
+          {/* 第11項-第15項 */}
+          <li className="pb-1">他のユーザーに成りすます行為</li>
+          <li className="pb-1">
+            本サービスが許諾しない本サービス上での宣伝、広告、勧誘、または営業行為
+          </li>
+          <li className="pb-1">面識のない異性との出会いを目的とした行為</li>
+          <li className="pb-1">
+            本サービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為
+          </li>
+          <li className="pb-1">その他、本サービスが不適切と判断する行為</li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第6条（本サービスの提供の停止等）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスは、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+            <ul className="list-inside list-disc p-3">
+              <li>本サービスにかかるシステムの保守点検または更新を行う場合</li>
+              <li>
+                地震、落雷、火災、停電または天災などの不可抗力により、本サービスの提供が困難となった場合
+              </li>
+              <li>コンピュータまたは通信回線等が事故により停止した場合</li>
+              <li>その他、本サービスの提供が困難と判断した場合</li>
+            </ul>
+          </li>
+          <li className="pb-1">
+            本サービスは、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第7条（利用制限および登録抹消）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスは、ユーザーが以下のいずれかに該当する場合には、事前の通知なく、ユーザーに対して、本サービスの全部もしくは一部の利用を制限、またはユーザーとしての登録を抹消することができるものとします。
+            <ul className="list-inside list-disc p-3">
+              <li>本規約のいずれかの条項に違反した場合</li>
+              <li>登録事項に虚偽の事実があることが判明した場合</li>
+              <li>本サービスからの連絡に対し、一定期間返答がない場合</li>
+              <li>本サービスについて、最終の利用から一定期間利用がない場合</li>
+              <li>その他、本サービスの利用を適当でないと判断した場合</li>
+            </ul>
+          </li>
+          <li className="pb-1">
+            本サービスは、本条に基づき行った行為によりユーザーに生じた損害について、一切の責任を負いません。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第8条（退会）" />
+        <p className="text-justify text-base text-dark-black">
+          ユーザーは、本サービスの定める退会手続により、本サービスから退会できるものとします。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第9条（保証の否認および免責事項）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスは、事実上または法律上の瑕疵（安全性、信頼性、正確性、完全性、有効性、特定の目的への適合性、セキュリティなどに関する欠陥、エラーやバグ、権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。
+          </li>
+          <li className="pb-1">
+            本サービスは、ユーザーに生じたあらゆる損害について、一切の責任を負いません。
+          </li>
+          <li className="pb-1">
+            本サービスは、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第10条（サービス内容の変更等）" />
+        <p className="text-justify text-base text-dark-black">
+          本サービスは、ユーザーへの事前の告知をすることなく、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第11条（利用規約の変更）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">
+            本サービスは、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+          </li>
+          <li className="pb-1">
+            本サービスは、本規約の変更後にユーザーが本サービスを利用した場合、変更後の規約に同意したものとみなします。
+          </li>
+        </ol>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第12条（個人情報の取扱い）" />
+        <p className="text-justify text-base text-dark-black">
+          本サービスの利用によって取得する個人情報については、「プライバシーポリシー」に従い適切に取り扱うものとします。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第13条（通知または連絡）" />
+        <p className="text-justify text-base text-dark-black">
+          ユーザーと本サービスとの間の通知または連絡は、本サービスの定める方法によって行うものとします。現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い、発信時にユーザーへ到達したものとみなします。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第14条（権利義務の譲渡の禁止）" />
+        <p className="text-justify text-base text-dark-black">
+          ユーザーは、事前の承諾なく、利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し、または担保に供することはできません。
+        </p>
+      </div>
+
+      <div className="w-full">
+        <Provision text="第15条（準拠法・裁判管轄）" />
+        <ol className="list-inside list-decimal text-justify text-base text-dark-black">
+          <li className="pb-1">本規約の解釈にあたっては、日本法を準拠法とします。</li>
+          <li className="pb-1">
+            本サービスに関して紛争が生じた場合には、本サービスの運営者所在地を管轄する裁判所を専属的合意管轄とします。
+          </li>
+        </ol>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/Footer.jsx
+++ b/frontend/src/components/shared/Footer.jsx
@@ -32,7 +32,23 @@ export const Footer = () => {
             ))}
           </>
         ) : (
-          <p className="m-auto text-base text-ligth-white">© 2023 ponchoay</p>
+          <>
+            <div>
+              <Link
+                href="/terms"
+                className="px-6 py-[26px] text-xs text-ligth-white transition-colors duration-200 hover:bg-slate-200/50 sm:text-sm"
+              >
+                利用規約
+              </Link>
+              <Link
+                href="/privacy-policy"
+                className="px-2 py-[26px] text-xs text-ligth-white transition-colors duration-200  hover:bg-slate-200/50 sm:text-sm"
+              >
+                プライバシーポリシー
+              </Link>
+            </div>
+            <p className="px-4 text-xs text-ligth-white sm:text-sm">© 2023 ponchoay</p>
+          </>
         )}
       </div>
     </footer>

--- a/frontend/src/components/shared/Provision.jsx
+++ b/frontend/src/components/shared/Provision.jsx
@@ -1,0 +1,7 @@
+export const Provision = ({ text }) => {
+  return (
+    <h2 className="mb-2 border-b border-solid border-b-dark-blue pb-1 text-xl font-bold tracking-widest text-dark-blue ">
+      {text}
+    </h2>
+  )
+}

--- a/frontend/src/pages/privacy-policy.jsx
+++ b/frontend/src/pages/privacy-policy.jsx
@@ -1,0 +1,9 @@
+import { PrivacyPolicyPage } from 'src/components/pages/privacy-policy'
+
+export default function PrivacyPolicy() {
+  return (
+    <>
+      <PrivacyPolicyPage />
+    </>
+  )
+}

--- a/frontend/src/pages/terms.jsx
+++ b/frontend/src/pages/terms.jsx
@@ -1,0 +1,9 @@
+import { TermsPage } from 'src/components/pages/terms'
+
+export default function Terms() {
+  return (
+    <>
+      <TermsPage />
+    </>
+  )
+}


### PR DESCRIPTION
# 説明
以下のとおり利用規約(`/terms`)及びプライバシーポリシー(`/privacy-policy`)ページを追加しました。


### 修正前：
- サービスの利用に際して、利用規約及びプライバシーポリシーが存在しない。

### 修正後：
- 利用規約(`/terms`)及びプライバシーポリシー(`/privacy-policy`)ページを追加しました。
- 未ログインの場合にフッターに当該ページのリンクを追加しました。
- 新規登録ページ(`/signup`)に同意に関する文言と当該ページのリンクを追加しました。

### 修正理由：
- 法的要件を遵守することについて明確にし、ユーザーに安心してサービスを利用してもらうため。
- 不当な利用や知的財産権の侵害等からサービスを保護するため。

## 実装概要
- 利用規約・プライバシーポリシーページの追加 74e26ae e904536
- フッターに該当ページのリンクを追加 8706c90
- 新規登録ページに利用規約及びプライバシーポリシーの同意に関する文言及び該当ページのリンクを追加 7a47051


# スクリーンショット
- 利用規約ページ(`/terms`)を追加( 一部抜粋)

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |  ![スクリーンショット 2023-12-25 14 58 50](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/b381da02-e95f-4673-8250-09c25882b74a) |  

- プライバシーポリシーページ(`/privacy-policy`)を追加( 一部抜粋)

| 実装前 | 実装後 |
| ------------- | ------------- |
|  | ![スクリーンショット 2023-12-25 14 59 00](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/6f4de4bb-8455-418f-ad34-208bed826512)  |  

- フッターにリンクを追加

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2023-12-25 14 54 16](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/4b7b1ce5-12cf-4445-90d6-075387817be3) | ![スクリーンショット 2023-12-25 14 53 56](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/9b06916c-decd-4d9d-abac-ce071220abce)  |

- 新規登録ページ(`/signup`)に同意に関する文言とリンクを追加

| 実装前 | 実装後 |
| ------------- | ------------- |
|  ![スクリーンショット 2023-12-25 14 55 23](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/c6edef12-cef6-4e2a-876d-535a7080c6b4)| ![スクリーンショット 2023-12-25 14 55 38](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/a80ac0af-b783-48e3-b6e9-8aa891645227)  |



# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング

