### PR TITLE
本番環境でAWS S3に画像をアップロードする機能を追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -61,3 +61,4 @@ gem 'devise-i18n-views'
 
 # 画像アップロード用
 gem 'carrierwave'
+gem 'fog-aws'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -104,7 +104,24 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    excon (0.108.0)
     ffi (1.15.5)
+    fog-aws (3.21.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -127,10 +144,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1205)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.19.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.7)
       date
@@ -252,6 +273,7 @@ DEPENDENCIES
   devise-i18n-views
   devise_token_auth
   dotenv-rails
+  fog-aws
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rack-cors

--- a/backend/app/uploaders/chinchilla_image_uploader.rb
+++ b/backend/app/uploaders/chinchilla_image_uploader.rb
@@ -1,6 +1,10 @@
 class ChinchillaImageUploader < CarrierWave::Uploader::Base
-  # public/に保存
-  storage :file
+  # 本番環境ではS3、それ以外では/publicに保存する
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # 保存されるディレクトリを設定
   def store_dir

--- a/backend/app/uploaders/chinchilla_image_uploader.rb
+++ b/backend/app/uploaders/chinchilla_image_uploader.rb
@@ -11,4 +11,18 @@ class ChinchillaImageUploader < CarrierWave::Uploader::Base
   def extension_allowlist
     %w[jpg jpeg gif png]
   end
+
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  # 一意となるトークンを作成
+  protected
+
+  def secure_token(length = 16)
+    var = :"@#{mounted_as}_secure_token"
+    token = model.instance_variable_get(var)
+    token = model.instance_variable_set(var, SecureRandom.hex(length / 2)) if token.nil?
+    token
+  end
 end

--- a/backend/config/initializers/carrierwave.rb
+++ b/backend/config/initializers/carrierwave.rb
@@ -1,5 +1,33 @@
+# CarrierWaveの設定呼び出し
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+# 画像名に日本語が使えるようにする
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/
+
+# 保存先の分岐
 CarrierWave.configure do |config|
-  config.asset_host = "http://localhost:3010"
-  config.storage = :file
-  config.cache_storage = :file
+  if Rails.env.production?
+    # 本番環境はS3に保存
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = ENV["AWS_S3_BUCKET"]
+    config.asset_host = ENV["AWS_ASSET_HOST"]
+    # iam_profile
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: ENV["AWS_REGION"]
+    }
+    # キャッシュをS3に保存
+    config.cache_storage = :fog
+    # ファイルへのアクセスを非公開にする
+    config.fog_public = false
+  else
+    # 開発環境はlocalに保存
+    config.storage :file
+    config.enable_processing = false if Rails.env.test? #test:処理をスキップ
+  end
 end


### PR DESCRIPTION
# 説明
以下のとおり本番環境でAWS S3に画像をアップロードする機能を追加しました。


### 修正前：
- 開発環境では画像をアップロード(Rails publicディレクトリ)できるが、本番環境ではできない。

### 修正後：
- 本番環境の場合はAWS S3に画像をアップロードする機能を追加しました。

### 修正理由：
- 本番環境で画像をアップロードできるようにするため。

## 実装概要
- fog-awsをインストール 0569bdf
- ファイル名をランダムで付与する機能を追加 2a1bbb7
- 本番環境でAWS S3に画像をアップロードする機能を追加 4881b1b


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
