### PR TITLE
チンチラメモ及びお世話メモの追加・修正、その他修正漏れ対応

### DIFF
--- a/backend/app/models/care.rb
+++ b/backend/app/models/care.rb
@@ -37,8 +37,8 @@ class Care < ApplicationRecord
             numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100 },
             allow_nil: true
 
-  # care_memoのバリデーション（200文字以下）
-  validates :care_memo, length: { maximum: 200 }
+  # care_memoのバリデーション（500文字以下）
+  validates :care_memo, length: { maximum: 500 }
 
   private
 

--- a/backend/app/models/chinchilla.rb
+++ b/backend/app/models/chinchilla.rb
@@ -43,6 +43,6 @@ class Chinchilla < ApplicationRecord
     errors.add(:chinchilla_met_day, 'は誕生日よりも過去の日付に設定できません')
   end
 
-  # chinchilla_memoのバリデーション（200文字以下）
-  validates :chinchilla_memo, length: { maximum: 200 }
+  # chinchilla_memoのバリデーション（500文字以下）
+  validates :chinchilla_memo, length: { maximum: 500 }
 end

--- a/backend/config/initializers/carrierwave.rb
+++ b/backend/config/initializers/carrierwave.rb
@@ -27,6 +27,7 @@ CarrierWave.configure do |config|
     config.fog_public = false
   else
     # 開発環境はlocalに保存
+    config.asset_host = 'http://localhost:3010'
     config.storage :file
     config.enable_processing = false if Rails.env.test? #test:処理をスキップ
   end

--- a/backend/db/migrate/20231227120007_change_chinchilla_memo_limit500.rb
+++ b/backend/db/migrate/20231227120007_change_chinchilla_memo_limit500.rb
@@ -1,0 +1,5 @@
+class ChangeChinchillaMemoLimit500 < ActiveRecord::Migration[7.0]
+  def change
+    change_column :chinchillas, :chinchilla_memo, :string, limit: 500
+  end
+end

--- a/backend/db/migrate/20231227120722_change_care_memo_limit500.rb
+++ b/backend/db/migrate/20231227120722_change_care_memo_limit500.rb
@@ -1,0 +1,5 @@
+class ChangeCareMemoLimit500 < ActiveRecord::Migration[7.0]
+  def change
+    change_column :cares, :care_memo, :string, limit: 500
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_14_044025) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_27_120007) do
   create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "care_day", null: false
     t.string "care_food"
@@ -36,7 +36,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_044025) do
     t.string "chinchilla_sex", null: false
     t.date "chinchilla_birthday"
     t.date "chinchilla_met_day"
-    t.string "chinchilla_memo", limit: 200
+    t.string "chinchilla_memo", limit: 500
     t.string "chinchilla_image"
     t.bigint "user_id"
     t.datetime "created_at", null: false

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_27_120007) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_27_120722) do
   create_table "cares", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "care_day", null: false
     t.string "care_food"
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_27_120007) do
     t.integer "care_weight"
     t.float "care_temperature"
     t.integer "care_humidity"
-    t.string "care_memo", limit: 200
+    t.string "care_memo", limit: 500
     t.string "care_image1"
     t.string "care_image2"
     t.string "care_image3"

--- a/frontend/src/components/pages/care-record-calendar/careMemoFormItem.jsx
+++ b/frontend/src/components/pages/care-record-calendar/careMemoFormItem.jsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFilePen } from '@fortawesome/free-solid-svg-icons'
 
-export const CareMemoFormItem = ({ careMemo, setCareMemo }) => {
+export const CareMemoFormItem = ({ careMemo, onChange, careMemoErrorMessage }) => {
   return (
     <div className="form-control h-96 w-80 sm:h-[464px] sm:w-[500px]">
       <label htmlFor="careMemo" className="mx-1 my-2 flex">
@@ -15,9 +15,12 @@ export const CareMemoFormItem = ({ careMemo, setCareMemo }) => {
         id="careMemo"
         placeholder="メモを記入してください。"
         value={careMemo}
-        onChange={(event) => setCareMemo(event.target.value)}
+        onChange={onChange}
         className="textarea textarea-primary h-80 border-dark-blue bg-ligth-white text-base text-dark-black sm:h-96"
       ></textarea>
+      {careMemoErrorMessage && (
+        <p className="label text-sm text-dark-pink sm:text-base">{careMemoErrorMessage}</p>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/pages/care-record-calendar/index.jsx
+++ b/frontend/src/components/pages/care-record-calendar/index.jsx
@@ -16,6 +16,8 @@ import { Calendar } from 'src/components/pages/care-record-calendar/calendar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHandPointer } from '@fortawesome/free-solid-svg-icons'
 
+import { validateCareMemo } from 'src/validation/care'
+
 import { format } from 'date-fns'
 import ja from 'date-fns/locale/ja'
 
@@ -43,6 +45,9 @@ export const CareRecordCalendarPage = () => {
   const [careTemperature, setCareTemperature] = useState(null)
   const [careHumidity, setCareHumidity] = useState(null)
   const [careMemo, setCareMemo] = useState('')
+
+  // お世話メモのバリデーションメッセージ
+  const [careMemoErrorMessage, setCareMemoErrorMessage] = useState('')
 
   // 選択中のカレンダーの日付の状態管理
   const [selectedDate, setSelectedDate] = useState(null)
@@ -201,6 +206,16 @@ export const CareRecordCalendarPage = () => {
     formData.append('care[careMemo]', careMemo)
     formData.append('care[chinchillaId]', chinchillaId)
     return formData
+  }
+
+  // お世話メモのセット関数
+  const handleCareMemoChange = (e) => {
+    const newText = e.target.value
+
+    // お世話メモの字数確認
+    validateCareMemo(newText, setCareMemoErrorMessage)
+
+    setCareMemo(newText)
   }
 
   // create;お世話の記録を登録
@@ -372,15 +387,19 @@ export const CareRecordCalendarPage = () => {
           />
 
           {/* 登録モード：お世話のメモ */}
-          <CareMemoFormItem careMemo={careMemo} setCareMemo={setCareMemo} />
+          <CareMemoFormItem
+            careMemo={careMemo}
+            onChange={handleCareMemoChange}
+            careMemoErrorMessage={careMemoErrorMessage}
+          />
 
           {/* 登録モード：登録ボタン */}
           <Button
             btnType="submit"
             click={handleCreate}
             disabled={
-              // 「チンチラを選択していない」または「日付を選択していない」または「お世話記録を全て選択していない」場合は登録できない
-              // 「チンチラを選択している」かつ「日付を選択している」かつ「お世話記録を何か選択している」場合のみ登録できる
+              // 「チンチラを選択していない」または「日付を選択していない」または「お世話記録を全て選択していない」または「バリデーションエラーがある」場合は登録できない
+              // 「チンチラを選択している」かつ「日付を選択している」かつ「お世話記録を何か選択している」かつ「バリデーションエラーがない」場合のみ登録できる
               !chinchillaId ||
               !selectedDate ||
               (!careFood &&
@@ -390,7 +409,8 @@ export const CareRecordCalendarPage = () => {
                 !careWeight &&
                 !careTemperature &&
                 !careHumidity &&
-                !careMemo)
+                !careMemo) ||
+              careMemoErrorMessage
                 ? true
                 : false
             }
@@ -474,7 +494,11 @@ export const CareRecordCalendarPage = () => {
               />
 
               {/* 編集モード：お世話のメモ */}
-              <CareMemoFormItem careMemo={careMemo} setCareMemo={setCareMemo} />
+              <CareMemoFormItem
+                careMemo={careMemo}
+                onChange={handleCareMemoChange}
+                careMemoErrorMessage={careMemoErrorMessage}
+              />
 
               {/* 編集モード：保存・戻るボタン */}
               <div>
@@ -493,7 +517,8 @@ export const CareRecordCalendarPage = () => {
                       !careWeight &&
                       !careTemperature &&
                       !careHumidity &&
-                      !careMemo)
+                      !careMemo) ||
+                    careMemoErrorMessage
                       ? true
                       : false
                   }

--- a/frontend/src/validation/care.js
+++ b/frontend/src/validation/care.js
@@ -1,0 +1,7 @@
+export const validateCareMemo = (newText, setCareMemoErrorMessage) => {
+  if (newText.length > 300) {
+    setCareMemoErrorMessage('300文字以下で入力してください')
+  } else {
+    setCareMemoErrorMessage('')
+  }
+}

--- a/frontend/src/validation/chinchilla.js
+++ b/frontend/src/validation/chinchilla.js
@@ -63,7 +63,7 @@ export const chinchillaProfileSchema = z
     chinchillaSex: z.string().nonempty('性別は必須です'),
     chinchillaBirthday: z.string().nullable(),
     chinchillaMetDay: z.string().nullable(),
-    chinchillaMemo: z.string().max(200, '200文字以下で入力してください')
+    chinchillaMemo: z.string().max(300, '300文字以下で入力してください')
   })
   // 第一引数の条件がfalseの場合に、第二引数のメッセージを表示
   .refine(


### PR DESCRIPTION
# 説明
以下のとおりチンチラメモ及びお世話メモの追加・修正を行いました。また、#71 の修正漏れも併せて対応しました。


### 修正前：
- 開発環境において、画像を取得するAPIのホストがlocalhost:3000(フロントエンド)になっている。#71 の修正漏れ。
- チンチラメモについて、フロントエンド側では改行を1文字、バックエンド側(DB・モデル)では改行を2文字を扱うことが原因で、フロントエンドではクリアしても、バックエンドでエラーになることがある。
- フロントエンド側で、お世話メモの字数制限のバリデーションが設定されていない。

### 修正後：
- localhost:3010にリクエストするよう修正しました。
- バックエンド側(DB・モデル)のチンチラメモ及びお世話メモの字数を200文字から500文字に修正しました。
- フロントエンド側のチンチラメモについて、字数制限のバリデーションを200文字から300文字に修正しました。
- フロントエンド側のお世話メモについて、字数制限のバリデーションを300文字で設定しました。

### 修正理由：
- 開発環境において、アップロードした画像を取得しようとするとステータスコード404のエラーになるため。
- フロントエンド側とバックエンド側で改行コードの扱いが異なることから、改行を複数回行ってもエラーにならないようフロントエンドとバックエンドの文字数の設定に幅をもたせた。
- フロントエンド側において、上限200文字では少ないと考えられたため、上限300文字に変更した。

## 実装概要
- 開発環境でアップロードした画像が取得できない問題を修正 88ae1aa
- バックエンド側において、チンチラメモ及びお世話メモの字数制限を変更 0531813 56fb30c
- フロントエンド側において、チンチラメモ及びお世話メモの字数制限の変更・追加 2948e46 b91bfee

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
