### PR TITLE
iPhone/iPadでTOPページをリロード等するとカルーセルの画像が極端に小さく表示される問題の修正

### DIFF
--- a/frontend/src/components/pages/index/Carousel.jsx
+++ b/frontend/src/components/pages/index/Carousel.jsx
@@ -29,7 +29,7 @@ export const Carousel = () => {
   ]
 
   return (
-    <div className="w-full max-w-screen-sm">
+    <div className="w-[351px] sm:w-[616px]">
       <div className="carousel">
         {carouselItems.map((item) => (
           <React.Fragment key={item.slideId}>

--- a/frontend/src/components/pages/index/Carousel.jsx
+++ b/frontend/src/components/pages/index/Carousel.jsx
@@ -30,16 +30,16 @@ export const Carousel = () => {
 
   return (
     <div className="w-[351px] sm:w-[616px]">
-      <div className="carousel">
+      <div className="carousel w-full">
         {carouselItems.map((item) => (
           <React.Fragment key={item.slideId}>
-            <div id={item.slideId} className="carousel-item aspect-[3/2] h-auto w-full ">
+            <div id={item.slideId} className="carousel-item w-full">
               <img
                 src={item.src}
                 width="336"
                 height="224"
                 alt={item.alt}
-                className={`aspect-[3/2] h-auto w-full rounded-lg ${item.addStyle}`}
+                className={` w-full rounded-lg ${item.addStyle}`}
               />
             </div>
           </React.Fragment>


### PR DESCRIPTION
# 説明
以下のとおりiPhone/iPadでTOPページをリロード等するとカルーセルの画像が極端に小さく表示される問題を修正しました。


### 修正前：
- #74 のとおり、iPhone/iPadでTOPページ(`/`)をリロード等するとカルーセルの画像が極端に小さく表示される。

### 修正後：
- カルーセルの画像を画面幅にあわせて画像サイズを可変にしているのをやめ、スマホサイズ及び幅640px以上の2サイズに変更しました。

### 修正理由：
- CSSプロパティ aspect-ratioが原因はであることがわかり、3:2の画像比率を保ったまま完全にレスポンシブにすると本事象が起こることから、上記の2パターンの対応に変更した。

## 実装概要
- カルーセルの画像が極端に小さく表示される問題を修正 65a395d 44d35f4

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
