### PR TITLE
マイチンチラページをリロード等すると初回レンダリングで表示がちらつく問題の修正

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react-hook-form": "^7.45.4",
         "react-number-format": "^5.3.1",
         "recharts": "^2.8.0",
+        "swr": "^2.2.4",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.7",
@@ -6939,6 +6940,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
@@ -7340,6 +7353,14 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "react-hook-form": "^7.45.4",
     "react-number-format": "^5.3.1",
     "recharts": "^2.8.0",
+    "swr": "^2.2.4",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -19,7 +19,7 @@ export const MyChinchillaPage = () => {
 
       {!isLoading && chinchillas.length === 0 && <NoChinchillaFound />}
 
-      {!isLoading && chinchillas.length !== 0 && <MyChinchillaList chinchillas={chinchillas} />}
+      {!isLoading && chinchillas.length !== 0 && <MyChinchillaList />}
 
       <Link href="/chinchilla-registration">
         <button

--- a/frontend/src/components/pages/mychinchilla/index.jsx
+++ b/frontend/src/components/pages/mychinchilla/index.jsx
@@ -1,91 +1,26 @@
-import { useEffect, useState, useContext } from 'react'
 import Link from 'next/link'
-import { getMyChinchillas } from 'src/lib/api/chinchilla'
-import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+import { useMyChinchillas } from 'src/lib/api/chinchilla'
 
 import { PageTitle } from 'src/components/shared/PageTittle'
-import { Button } from 'src/components/shared/Button'
+import { LoadingDots } from 'src/components/shared/LoadingDots'
+import { NoChinchillaFound } from 'src/components/pages/mychinchilla/noChinchillaFound'
+import { MyChinchillaList } from 'src/components/pages/mychinchilla/myChinchillaList'
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 
-import { debugLog } from 'src/lib/debug/debugLog'
-
 export const MyChinchillaPage = () => {
-  const [allChinchillas, setAllChinchillas] = useState([])
-  const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
-
-  const fetch = async () => {
-    try {
-      const res = await getMyChinchillas()
-      debugLog('マイチンチラ:', res.data)
-      setAllChinchillas(res.data)
-    } catch (err) {
-      debugLog('エラー:', err)
-    }
-  }
-
-  useEffect(() => {
-    fetch()
-  }, [])
+  const { chinchillas, isLoading } = useMyChinchillas()
 
   return (
     <div className="mx-auto my-24 grid place-content-center place-items-center sm:my-28">
       <PageTitle pageTitle="マイチンチラ" />
-      {allChinchillas.length === 0 ? (
-        <>
-          <div className="mt-6 grid grid-cols-1 place-items-center">
-            <img
-              src="/images/no-chinchilla-found.svg"
-              width="200"
-              height="200"
-              alt="プロフィール画像"
-              className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
-            />
-            <p className="w-[200px] text-center text-base text-dark-black">チンチラがいません</p>
-          </div>
+      {isLoading && <LoadingDots />}
 
-          <Link href="/chinchilla-registration">
-            <Button btnType="button" addStyle="btn-secondary h-14 w-32 mt-6">
-              登録する
-            </Button>
-          </Link>
-        </>
-      ) : (
-        <div
-          className={`mt-6 grid grid-cols-1 ${
-            allChinchillas.length === 1
-              ? 'place-items-center'
-              : 'gap-y-10 sm:grid-cols-2 sm:gap-x-20'
-          }`}
-        >
-          {allChinchillas.map((chinchilla) => (
-            <div key={chinchilla.id}>
-              <Link
-                href="/mychinchilla/chinchilla-profile"
-                onClick={() => setChinchillaId(chinchilla.id)}
-                className="text-center"
-              >
-                <div>
-                  <img
-                    src={
-                      chinchilla.chinchillaImage?.url
-                        ? chinchilla.chinchillaImage.url
-                        : '/images/default.svg'
-                    }
-                    width="200"
-                    height="200"
-                    alt="プロフィール画像"
-                    className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
-                  />
-                  <p className="w-[200px] text-center text-base text-dark-black">
-                    {chinchilla.chinchillaName}
-                  </p>
-                </div>
-              </Link>
-            </div>
-          ))}
-        </div>
-      )}
+      {!isLoading && chinchillas.length === 0 && <NoChinchillaFound />}
+
+      {!isLoading && chinchillas.length !== 0 && <MyChinchillaList chinchillas={chinchillas} />}
+
       <Link href="/chinchilla-registration">
         <button
           type="button"

--- a/frontend/src/components/pages/mychinchilla/myChinchillaList.jsx
+++ b/frontend/src/components/pages/mychinchilla/myChinchillaList.jsx
@@ -1,0 +1,44 @@
+import { useContext } from 'react'
+import Link from 'next/link'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
+export const MyChinchillaList = ({ chinchillas }) => {
+  const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
+
+  return (
+    <>
+      <div
+        className={`mt-6 grid grid-cols-1 ${
+          chinchillas.length === 1 ? 'place-items-center' : 'gap-y-10 sm:grid-cols-2 sm:gap-x-20'
+        }`}
+      >
+        {chinchillas.map((chinchilla) => (
+          <div key={chinchilla.id}>
+            <Link
+              href="/mychinchilla/chinchilla-profile"
+              onClick={() => setChinchillaId(chinchilla.id)}
+              className="text-center"
+            >
+              <div>
+                <img
+                  src={
+                    chinchilla.chinchillaImage?.url
+                      ? chinchilla.chinchillaImage.url
+                      : '/images/default.svg'
+                  }
+                  width="200"
+                  height="200"
+                  alt="プロフィール画像"
+                  className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
+                />
+                <p className="w-[200px] text-center text-base text-dark-black">
+                  {chinchilla.chinchillaName}
+                </p>
+              </div>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/pages/mychinchilla/myChinchillaList.jsx
+++ b/frontend/src/components/pages/mychinchilla/myChinchillaList.jsx
@@ -1,8 +1,10 @@
 import { useContext } from 'react'
 import Link from 'next/link'
+import { useMyChinchillas } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
-export const MyChinchillaList = ({ chinchillas }) => {
+export const MyChinchillaList = () => {
+  const { chinchillas } = useMyChinchillas()
   const { setChinchillaId } = useContext(SelectedChinchillaIdContext)
 
   return (

--- a/frontend/src/components/pages/mychinchilla/noChinchillaFound.jsx
+++ b/frontend/src/components/pages/mychinchilla/noChinchillaFound.jsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Button } from 'src/components/shared/Button'
+
+export const NoChinchillaFound = () => {
+  return (
+    <>
+      <div className="mt-6 grid grid-cols-1 place-items-center">
+        <img
+          src="/images/no-chinchilla-found.svg"
+          width="200"
+          height="200"
+          alt="プロフィール画像"
+          className="mb-3 h-[200px] w-[200px] rounded-3xl border border-solid border-ligth-white bg-ligth-white"
+        />
+        <p className="w-[200px] text-center text-base text-dark-black">チンチラがいません</p>
+      </div>
+
+      <Link href="/chinchilla-registration">
+        <Button btnType="button" addStyle="btn-secondary h-14 w-32 mt-6">
+          登録する
+        </Button>
+      </Link>
+    </>
+  )
+}

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -1,7 +1,37 @@
 import Cookies from 'js-cookie'
+import useSWR from 'swr'
 import { client } from 'src/lib/api/client'
 
 // 機能&リクエストURL
+
+const fetchWithToken = (url) => {
+  const accessToken = Cookies.get('_access_token')
+  const clientToken = Cookies.get('_client')
+  const uid = Cookies.get('_uid')
+
+  if (!accessToken || !client || !uid) return
+
+  return client
+    .get(url, {
+      headers: {
+        'access-token': accessToken,
+        client: clientToken,
+        uid: uid
+      }
+    })
+    .then((res) => res.data)
+}
+
+// マイチンチラページ用 id, chinchillaName, chinchillaImageを取得
+export const useMyChinchillas = () => {
+  const { data, error, isLoading } = useSWR('/my_chinchillas', fetchWithToken)
+
+  return {
+    chinchillas: data,
+    isLoading,
+    isError: error
+  }
+}
 
 // マイチンチラページ用 id, chinchillaName, chinchillaImageを取得
 export const getMyChinchillas = () => {

--- a/frontend/src/lib/api/chinchilla.js
+++ b/frontend/src/lib/api/chinchilla.js
@@ -33,7 +33,7 @@ export const useMyChinchillas = () => {
   }
 }
 
-// マイチンチラページ用 id, chinchillaName, chinchillaImageを取得
+// ヘッダー用 id, chinchillaName, chinchillaImageを取得
 export const getMyChinchillas = () => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.get('/my_chinchillas', {


### PR DESCRIPTION
# 説明
以下のとおりマイチンチラページ(`/mychinchilla`)において、チンチラが登録されている場合にリロードや他のページから遷移すると、マイチンチラのデータ取得が完了する前にチンチラを登録していない場合のコンポーネントが一瞬表示され、その後マイチンチラのデータが表示される問題を修正しました。

### 修正前：
- マイチンチラページ(`/mychinchilla`)において、チンチラが登録されている場合にリロードや他のページから遷移すると、useEffectが発火し、マイチンチラのデータ取得が完了する前にチンチラを登録していない場合のコンポーネントが一瞬表示され、その後マイチンチラのデータが表示される。

### 修正後：
- SWRを使って、データ取得が完了するまではローディング画面を表示し、完了後に各コンポーネントを表示するように修正しました。

### 修正理由：
- UI/UXの向上のため。

## 実装概要
- SWRのインストール dadbb9d
- マイチンチラページのデータ取得・状態管理の修正 c61709a 285c2b6 67e544a

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
