### PR TITLE
ログイン中にリロードすると初回レンダリングで未ログイン時の表示がちらつく問題の修正

### DIFF
--- a/frontend/src/components/shared/Header/index.jsx
+++ b/frontend/src/components/shared/Header/index.jsx
@@ -92,7 +92,9 @@ export const Header = () => {
             />
           </div>
         </Link>
-        {isSignedIn && currentUser ? (
+
+        {/* ログイン時 */}
+        {isSignedIn === true && currentUser && (
           <>
             {/* 選択中のチンチラ */}
             <DisplaySelectChinchilla
@@ -123,8 +125,10 @@ export const Header = () => {
               </Link>
             </div>
           </>
-        ) : (
-          // 未ログイン時
+        )}
+
+        {/* 未ログイン時 */}
+        {isSignedIn === false && currentUser === null && (
           <div className="flex h-full items-center">
             {userLinkItems.map((item) => (
               <Link

--- a/frontend/src/contexts/auth.js
+++ b/frontend/src/contexts/auth.js
@@ -7,7 +7,7 @@ export const AuthContext = createContext({})
 
 //_app.jsにエクスポートして、全体の親にする
 export const AuthProvider = ({ children }) => {
-  const [isSignedIn, setIsSignedIn] = useState(false)
+  const [isSignedIn, setIsSignedIn] = useState(undefined)
   const [currentUser, setCurrentUser] = useState(undefined)
   const [processUser, setProcessUser] = useState(undefined)
   const value = {
@@ -31,6 +31,8 @@ export const AuthProvider = ({ children }) => {
 
         debugLog('ログインユーザー:', res?.data.data)
       } else {
+        setIsSignedIn(false)
+        setCurrentUser(null)
         debugLog('ログインユーザー:', 'No current user')
       }
     } catch (err) {


### PR DESCRIPTION
# 説明
以下のとおりヘッダーにおいて、ログイン中にリロードすると、未ログイン時に表示したい「新規登録」「ログイン」ボタンが一瞬表示され、その後「マイページ」ボタンが表示される問題を修正しました。


### 修正前：
- ヘッダーにおいて、ログイン中にリロードすると、未ログイン時に表示したい「新規登録」「ログイン」ボタンが一瞬表示され、その後「マイページ」ボタンが表示される。

### 修正後：
- ログイン状態をチェックしていない状態を「undefined」、ログインチェック後にログインしていないことが判明した状態を「false」とし、trueまたはfalseの時にヘッダーを要素を出し分けるように修正しました。

### 修正理由：
- UI/UXの向上のため。

## 実装概要
- ログイン状態のチェックロジックを修正 71412aa


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
