### PR TITLE
Rspecを利用したコントローラーテストを導入

### DIFF
--- a/backend/app/controllers/api/v1/tests_controller.rb
+++ b/backend/app/controllers/api/v1/tests_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::TestsController < ApplicationController
   def index
-    render json: { message: 'Hello, world!!' }
+    render json: { message: 'Hello, world!!' }, status: :ok
   end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -19,8 +19,8 @@ require 'rspec/rails'
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-#
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+# spec/support/配下のファイルを読み込む
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -71,4 +71,8 @@ RSpec.configure do |config|
       with.library :rails
     end
   end
+
+  # devise_token_auth用の自作ヘルパーメソッド
+  config.include RequestHelper, type: :request
+
 end

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -1,0 +1,287 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/cares', type: :request do
+  let!(:user) { create(:user) }
+  let!(:chinchilla) { create(:chinchilla, user: user) }
+
+  # JSONデータの中身を確認するためのkeyの配列
+  let(:my_chinchillas_keys) { ['chinchilla_name', 'chinchilla_image'] }
+  let(:chinchilla_keys) { ['chinchilla_name', 'chinchilla_sex', 'chinchilla_birthday', 'chinchilla_met_day', 'chinchilla_memo', 'chinchilla_image'] }
+
+  # ヘルパーモジュールのサインインメソッドを使用
+  before do
+    @headers = sign_in(user)
+  end
+
+  # 無効なヘッダー情報用
+  before do
+    @error_headers = {
+      'uid' => 'error@example.com',
+      'client' => 'error_client',
+      'access-token' => 'error_access_token'
+    }
+  end
+
+  describe 'GET /api/v1/all_cares' do
+    let!(:care) { create(:care, chinchilla: chinchilla) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        # シングルクォートだと式展開が行われない
+        get "/api/v1/all_cares?chinchilla_id=#{chinchilla.id}", headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'bodyに期待されるkeyが含まれること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response.first.keys).to contain_exactly('id', 'care_day', 'care_food', 'care_toilet', 'care_bath',
+                                                            'care_play', 'care_weight', 'care_temperature',
+                                                            'care_humidity', 'care_memo', 'care_image1', 'care_image2',
+                                                            'care_image3' , 'chinchilla_id', 'created_at', 'updated_at'
+                                                            )
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        get "/api/v1/all_cares?chinchilla_id=#{chinchilla.id}"
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        get "/api/v1/all_cares?chinchilla_id=#{chinchilla.id}", headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/weight_cares' do
+    let!(:care1) { create(:care, chinchilla: chinchilla, care_day: 1.day.ago, care_weight: 500) }
+    let!(:care2) { create(:care, chinchilla: chinchilla, care_day: 10.day.ago, care_weight: 550) }
+    let!(:care3) { create(:care, chinchilla: chinchilla, care_day: 5.day.ago, care_weight: 450) }
+    let!(:care4) { create(:care, chinchilla: chinchilla, care_day: 20.day.ago, care_weight: 400) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        get "/api/v1/weight_cares?chinchilla_id=#{chinchilla.id}", headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'bodyに期待されるkeyが含まれること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response.first.keys).to contain_exactly('care_day', 'care_weight')
+      end
+
+      it '配列の並び順がcare_dayの昇順であること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response.map { |care| care['care_day'] })
+        .to eq([care4, care2, care3, care1].map { |care| care.care_day.to_s } )
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        get "/api/v1/weight_cares?chinchilla_id=#{chinchilla.id}"
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        get "/api/v1/weight_cares?chinchilla_id=#{chinchilla.id}", headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/cares' do
+    let(:valid_params) { { care: attributes_for(:care, chinchilla_id: chinchilla.id) } }
+    let(:invalid_care_day_params) { { care: attributes_for(:care, care_day: '') } }
+    let(:invalid_care_food_params) { { care: attributes_for(:care, care_food: '普通') } }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      it 'データベースにレコードが追加されること' do
+        expect {
+          post '/api/v1/cares', params: valid_params, headers: @headers
+        }.to change(Care, :count).by(1)
+      end
+
+      it 'ステータスコード201が返ってくること' do
+        post '/api/v1/cares', params: valid_params, headers: @headers
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'care_dayを無効な値でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+        expect {
+          post '/api/v1/cares', params: invalid_care_day_params, headers: @headers
+        }.not_to change(Care, :count)
+    end
+
+      it 'ステータスコード422が返ってくること' do
+        post '/api/v1/cares', params: invalid_care_day_params, headers: @headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'care_foodを無効な値でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+        expect {
+          post '/api/v1/cares', params: invalid_care_food_params, headers: @headers
+        }.not_to change(Care, :count)
+    end
+
+      it 'ステータスコード422が返ってくること' do
+        post '/api/v1/cares', params: invalid_care_food_params, headers: @headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+          expect {
+            post '/api/v1/cares', params: valid_params
+          }.not_to change(Care, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        post '/api/v1/cares', params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+          expect {
+            post '/api/v1/cares', params: valid_params, headers: @error_headers
+          }.not_to change(Care, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        post '/api/v1/cares', params: valid_params, headers: @error_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/cares/:id' do
+    let!(:care) { create(:care, chinchilla: chinchilla) }
+    let(:valid_update_params) { { care: { care_memo: 'アップデート' } } }
+    let(:invalid_update_params) { { care: { care_food: '普通' } } }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        put "/api/v1/cares/#{care.id}", params: valid_update_params, headers: @headers
+      end
+
+      it 'リクエストがあったレコードが更新されていること' do
+        care.reload
+        expect(care.care_memo).to eq('アップデート')
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '不正なパラメーターでリクエストしたとき' do
+      before do
+        put "/api/v1/cares/#{care.id}", params: invalid_update_params, headers: @headers
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        care.reload
+        expect(care.care_food).not_to eq('普通')
+      end
+
+      it 'ステータスコード422が返ってくること' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        put "/api/v1/cares/#{care.id}"
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        put "/api/v1/cares/#{care.id}", headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/cares/:id' do
+    let!(:care) { create(:care, chinchilla: chinchilla) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      it 'データベースのレコードが削除されること' do
+        expect {
+        delete "/api/v1/cares/#{care.id}", headers: @headers
+        }.to change(Care, :count).by(-1)
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      it 'データベースのレコードが削除されないこと' do
+        expect {
+        delete "/api/v1/cares/#{care.id}"
+        }.not_to change(Care, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        delete "/api/v1/cares/#{care.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      it 'データベースのレコードが削除されないこと' do
+        expect {
+        delete "/api/v1/cares/#{care.id}", headers: @error_headers
+        }.not_to change(Care, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        delete "/api/v1/cares/#{care.id}", headers: @error_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -1,0 +1,277 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/chinchillas', type: :request do
+  let!(:user) { create(:user) }
+
+  # JSONデータの中身を確認するためのkeyの配列
+  let(:my_chinchillas_keys) { ['chinchilla_name', 'chinchilla_image'] }
+  let(:chinchilla_keys) { ['chinchilla_name', 'chinchilla_sex', 'chinchilla_birthday', 'chinchilla_met_day', 'chinchilla_memo', 'chinchilla_image'] }
+
+  # ヘルパーモジュールのサインインメソッドを使用
+  before do
+    @headers = sign_in(user)
+  end
+
+  # 無効なヘッダー情報用
+  before do
+    @error_headers = {
+      'uid' => 'error@example.com',
+      'client' => 'error_client',
+      'access-token' => 'error_access_token'
+    }
+  end
+
+  describe 'GET /api/v1/my_chinchillas' do
+    let!(:chinchilla) { create(:chinchilla, user: user) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        get '/api/v1/my_chinchillas', headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'bodyに期待されるkeyが含まれること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response.first.keys).to contain_exactly('id', 'chinchilla_name', 'chinchilla_image')
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        get '/api/v1/my_chinchillas'
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        get '/api/v1/my_chinchillas', headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/chinchillas/:id' do
+    let!(:chinchilla) { create(:chinchilla, user: user) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        # シングルクォートだと式展開が行われない
+        get "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'JSONデータの中身のidが一致していること' do
+        expect(response.parsed_body['id']).to eq(chinchilla.id)
+      end
+
+      it 'bodyに期待されるkeyが含まれること' do
+        chinchilla_keys.each do |key|
+          expect(response.parsed_body).to have_key(key)
+        end
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        get "/api/v1/chinchillas/#{chinchilla.id}"
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        get "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/chinchillas' do
+    let(:valid_params) { { chinchilla: attributes_for(:chinchilla) } }
+    let(:invalid_chinchilla_name_params) { { chinchilla: attributes_for(:chinchilla, chinchilla_name: '') } }
+    let(:invalid_chinchilla_sex_params) { { chinchilla: attributes_for(:chinchilla, chinchilla_sex: '男の子') } }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      it 'データベースにレコードが追加されること' do
+        expect {
+          post '/api/v1/chinchillas', params: valid_params, headers: @headers
+        }.to change(Chinchilla, :count).by(1)
+      end
+
+      it 'ステータスコード201が返ってくること' do
+        post '/api/v1/chinchillas', params: valid_params, headers: @headers
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'chinchilla_nameを無効な値でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+        expect {
+          post '/api/v1/chinchillas', params: invalid_chinchilla_name_params, headers: @headers
+        }.not_to change(Chinchilla, :count)
+    end
+
+      it 'ステータスコード422が返ってくること' do
+        post '/api/v1/chinchillas', params: invalid_chinchilla_name_params, headers: @headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'chinchilla_sexを無効な値でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+        expect {
+          post '/api/v1/chinchillas', params: invalid_chinchilla_sex_params, headers: @headers
+        }.not_to change(Chinchilla, :count)
+    end
+
+      it 'ステータスコード422が返ってくること' do
+        post '/api/v1/chinchillas', params: invalid_chinchilla_sex_params, headers: @headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+          expect {
+            post '/api/v1/chinchillas', params: valid_params
+          }.not_to change(Chinchilla, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        post '/api/v1/chinchillas', params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      it 'データベースにレコードが追加されないこと' do
+          expect {
+            post '/api/v1/chinchillas', params: valid_params, headers: @error_headers
+          }.not_to change(Chinchilla, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        post '/api/v1/chinchillas', params: valid_params, headers: @error_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/chinchillas/:id' do
+    let!(:chinchilla) { create(:chinchilla, user: user) }
+    let(:valid_update_params) { { chinchilla: { chinchilla_memo: 'アップデート' } } }
+    let(:invalid_update_params) { { chinchilla: { chinchilla_name: '' } } }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      before do
+        put "/api/v1/chinchillas/#{chinchilla.id}", params: valid_update_params, headers: @headers
+      end
+
+      it 'リクエストがあったレコードが更新されていること' do
+        chinchilla.reload
+        expect(chinchilla.chinchilla_memo).to eq('アップデート')
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '不正なパラメーターでリクエストしたとき' do
+      before do
+        put "/api/v1/chinchillas/#{chinchilla.id}", params: invalid_update_params, headers: @headers
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        chinchilla.reload
+        expect(chinchilla.chinchilla_name).not_to be_empty
+      end
+
+      it 'ステータスコード422が返ってくること' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      before do
+        put "/api/v1/chinchillas/#{chinchilla.id}"
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      before do
+        put "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/chinchillas/:id' do
+    let!(:chinchilla) { create(:chinchilla, user: user) }
+
+    context '正しいパラメーターでリクエストしたとき' do
+      it 'データベースのレコードが削除されること' do
+        expect {
+        delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
+        }.to change(Chinchilla, :count).by(-1)
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '非ログイン状態のユーザーがリクエストしたとき' do
+      it 'データベースのレコードが削除されないこと' do
+        expect {
+        delete "/api/v1/chinchillas/#{chinchilla.id}"
+        }.not_to change(Chinchilla, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        delete "/api/v1/chinchillas/#{chinchilla.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '誤ったトークン情報でリクエストしたとき' do
+      it 'データベースのレコードが削除されないこと' do
+        expect {
+        delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+        }.not_to change(Chinchilla, :count)
+      end
+
+      it 'ステータスコード401が返ってくること' do
+        delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/test_spec.rb
+++ b/backend/spec/requests/api/v1/test_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/test', type: :request do
+  it 'GET /api/v1/test' do
+    get '/api/v1/test'
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include({ message: 'Hello, world!!' }.to_json)
+  end
+end

--- a/backend/spec/support/request_helper.rb
+++ b/backend/spec/support/request_helper.rb
@@ -1,0 +1,12 @@
+module RequestHelper
+  # devise_token_auth認証用のサインインメソッド
+  def sign_in(user)
+    user.confirm # メールアドレス認証を入れているためこれが必要
+    post '/api/v1/auth/sign_in', params: { email: user.email, password: user.password }, headers: { Accept: 'application/json' }
+    {
+      'uid' => response.header['uid'],
+      'client' => response.header['client'],
+      'access-token' => response.header['access-token']
+    }
+  end
+end


### PR DESCRIPTION
# 説明
以下のとおりRspecを利用し、コントローラーのテストを導入しました。


### 修正前：
- コントローラーのテストコードを記述していない。

### 修正後：
- Rspecを利用し、test/chinchillas/caresコントローラーのテストを導入しました。
- testコントローラーについて、ステータスコードを明記しました。

### 修正理由：
- 実装の正しさを保証するため。
- 予期せぬバグを防ぐため。

## 実装概要
- Rspec導入のためのセットアップ 3ab9a26
- コントローラーの修正 045d091
- テストコードを追加 fc1bde7 c751810 13c7b6e fff69ca

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
