### PR TITLE
chinchillasコントローラー及びテストコードの追加・修正

### DIFF
--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -2,6 +2,9 @@ class Api::V1::ChinchillasController < ApplicationController
   # ログイン状態の確認
   before_action :authenticate_api_v1_user!
 
+  # ログイン中のユーザー所有のデータか確認
+  before_action :set_chinchilla, only: [:show, :update, :destroy]
+
   # ステータスコード404の共通処理
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
@@ -14,8 +17,7 @@ class Api::V1::ChinchillasController < ApplicationController
 
   # チンチラ個別プロフィール
   def show
-    chinchilla = Chinchilla.find(params[:id])
-    render json: chinchilla, status: :ok
+    render json: @chinchilla, status: :ok
   end
 
   # チンチラプロフィール 作成
@@ -34,10 +36,9 @@ class Api::V1::ChinchillasController < ApplicationController
 
   # チンチラプロフィール 更新
   def update
-    chinchilla = Chinchilla.find(params[:id])
-    if chinchilla.update(chinchilla_params)
+    if @chinchilla.update(chinchilla_params)
       # 成功した場合、ステータス200を返す
-      render json: chinchilla, status: :ok
+      render json: @chinchilla, status: :ok
     else
       # エラー文とステータス422を返す
       render json: { errors: ['チンチラの更新に失敗しました'] }, status: :unprocessable_entity
@@ -46,8 +47,7 @@ class Api::V1::ChinchillasController < ApplicationController
 
   # チンチラプロフィール 削除
   def destroy
-    chinchilla = Chinchilla.find(params[:id])
-    chinchilla.destroy
+    @chinchilla.destroy
     head :no_content
   end
 
@@ -58,6 +58,11 @@ class Api::V1::ChinchillasController < ApplicationController
       :chinchilla_name, :chinchilla_sex, :chinchilla_birthday,
       :chinchilla_met_day, :chinchilla_memo, :chinchilla_image
     )
+  end
+
+  def set_chinchilla
+    @chinchilla = current_api_v1_user.chinchillas.find_by(id: params[:id])
+    record_not_found unless @chinchilla
   end
 
   def record_not_found

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :user do
     provider { 'email' }
     uid { SecureRandom.uuid }
-    sequence(:email) { |n| 'test+#{n}@example.com' }
+    # シングルクォートだと式展開が行われない
+    sequence(:email) { |n| "test+#{n}@example.com" }
     password { 'password' }
   end
 end

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
       end
     end
 
+    context '指定したレコードが存在しないとき' do
+      before do
+        get '/api/v1/chinchillas/0', headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context '非ログイン状態のユーザーがリクエストしたとき' do
       before do
         get "/api/v1/chinchillas/#{chinchilla.id}"
@@ -236,6 +246,16 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
       end
     end
 
+    context '指定したレコードが存在しないとき' do
+      before do
+        put '/api/v1/chinchillas/0', params: invalid_update_params, headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'ログイン中の他のユーザーがリクエストしたとき' do
       before do
         put "/api/v1/chinchillas/#{chinchilla.id}", params: valid_update_params, headers: @other_headers
@@ -285,6 +305,16 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
       it 'ステータスコード204が返ってくること' do
         delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
         expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context '指定したレコードが存在しないとき' do
+      before do
+        delete '/api/v1/chinchillas/0', headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -273,7 +273,12 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       before do
-        put "/api/v1/chinchillas/#{chinchilla.id}"
+        put "/api/v1/chinchillas/#{chinchilla.id}", params: valid_update_params
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        chinchilla.reload
+        expect(chinchilla.chinchilla_memo).not_to eq('アップデート')
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -283,7 +288,12 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       before do
-        put "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+        put "/api/v1/chinchillas/#{chinchilla.id}", params: valid_update_params, headers: @error_headers
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        chinchilla.reload
+        expect(chinchilla.chinchilla_memo).not_to eq('アップデート')
       end
 
       it 'ステータスコード401が返ってくること' do

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
         expect {
           post '/api/v1/chinchillas', params: invalid_chinchilla_name_params, headers: @headers
         }.not_to change(Chinchilla, :count)
-    end
+      end
 
       it 'ステータスコード422が返ってくること' do
         post '/api/v1/chinchillas', params: invalid_chinchilla_name_params, headers: @headers
@@ -176,7 +176,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
         expect {
           post '/api/v1/chinchillas', params: invalid_chinchilla_sex_params, headers: @headers
         }.not_to change(Chinchilla, :count)
-    end
+      end
 
       it 'ステータスコード422が返ってくること' do
         post '/api/v1/chinchillas', params: invalid_chinchilla_sex_params, headers: @headers
@@ -186,9 +186,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-          expect {
-            post '/api/v1/chinchillas', params: valid_params
-          }.not_to change(Chinchilla, :count)
+        expect {
+          post '/api/v1/chinchillas', params: valid_params
+        }.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -199,9 +199,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-          expect {
-            post '/api/v1/chinchillas', params: valid_params, headers: @error_headers
-          }.not_to change(Chinchilla, :count)
+        expect {
+          post '/api/v1/chinchillas', params: valid_params, headers: @error_headers
+        }.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -298,7 +298,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースのレコードが削除されること' do
         expect {
-        delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
+          delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
         }.to change(Chinchilla, :count).by(-1)
       end
 
@@ -334,7 +334,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
         expect {
-        delete "/api/v1/chinchillas/#{chinchilla.id}"
+          delete "/api/v1/chinchillas/#{chinchilla.id}"
         }.not_to change(Chinchilla, :count)
       end
 
@@ -347,7 +347,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
         expect {
-        delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
+          delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
         }.not_to change(Chinchilla, :count)
       end
 


### PR DESCRIPTION
# 説明
以下のとおりchinchillasコントローラー及びテストコードを追加・修正しました。

### 修正前：
- show / update / destroyアクションについて、ログイン中のユーザーであれば、他のユーザーが所有するChinchillaモデルに関するレコードを操作できる。
- show / update / destroyアクションについて、存在しないidを指定してリクエストを行った場合のテストがない。
- updateアクションについて、非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合において、レコードが更新されないことを確認するテストがない。

### 修正後：
- ログイン中のユーザーが所有するデータのみ操作できるように修正しました。
- 上記の修正に関するテストコードを追加しました。
- 存在しないidを指定してリクエストを行った場合のテストコードを追加しました。
- 非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合に、レコードが更新されないことを確認するテストコードを追加しました。

### 修正理由：
- 実装の正しさを保証するため。
- 予期せぬバグを防ぐため。

## 実装概要
- chinchillasコントローラーの修正 b3d5609
- 他のユーザーによるレコード操作に関するテストコードの追加・修正 5950ec6 c3da4a6 
- 存在しないidを指定してリクエストを行った場合に関するテストコードを追加 b393a6b 
- インデントの修正 f2067b7 
- 非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合に関するテストコードを追加 9312c57

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
