### PR TITLE
Rubocop Rspecをインストールしてテストコードを修正

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -6,10 +6,14 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   # 新ルールを無効化
   NewCops: disable
+
+  # バージョン指定
+  TargetRubyVersion: 3.1.1
 
   # 対象外
   Exclude:
@@ -88,18 +92,54 @@ Metrics/CyclomaticComplexity:
 
 # 1行の文字数
 Layout/LineLength:
-  Max: 100
+  Max: 200
 
 # メソッドの行数
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - 'spec/**/*'
+    - 'config/**/*'
 
 # ブロックの行数
 Metrics/BlockLength:
-Max: 100
+  Exclude:
+    - 'spec/**/*'
+    - 'config/**/*'
+    - 'app/views/**/*'
 
 ##################### その他 ##################################
 
 # 日付のタイムゾーンの未設定を許可
 Rails/Date:
+  Enabled: false
+
+##################### Rspec関連 ##################################
+
+# プレフィックスの強制
+RSpec/ContextWording:
+  Enabled: false
+
+# 行数
+RSpec/ExampleLength:
+  Enabled: false
+
+# インスタンス変数を許可
+RSpec/InstanceVariable:
+  Enabled: false
+
+# let!を許可
+RSpec/LetSetup:
+  Enabled: false
+
+# itに対して複数の期待値を許可
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# let & subjectの複数呼び出しを許可
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# subject単独使用を許可
+RSpec/NamedSubject:
   Enabled: false

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -63,5 +63,6 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
   gem 'ruby-lsp', require: false
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -255,6 +255,10 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
     rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -262,6 +266,10 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
+    rubocop-rspec (2.26.1)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-lsp (0.12.3)
       language_server-protocol (~> 3.17.0)
       prism (>= 0.17.1, < 0.18)
@@ -308,6 +316,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  rubocop-rspec
   ruby-lsp
   shoulda-matchers
   tzinfo-data

--- a/backend/app/controllers/api/v1/chinchillas_controller.rb
+++ b/backend/app/controllers/api/v1/chinchillas_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ChinchillasController < ApplicationController
   before_action :authenticate_api_v1_user!
 
   # ログイン中のユーザー所有のデータか確認
-  before_action :set_chinchilla, only: [:show, :update, :destroy]
+  before_action :set_chinchilla, only: %i[show update destroy]
 
   # ステータスコード404の共通処理
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found

--- a/backend/spec/factories/chinchillas.rb
+++ b/backend/spec/factories/chinchillas.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :chinchilla do
     chinchilla_name { 'チンチラの名前' }
-    chinchilla_sex { ['オス', 'メス', '不明'].sample }
+    chinchilla_sex { %w[オス メス 不明].sample }
     chinchilla_birthday { 2.years.ago }
     chinchilla_met_day { 1.year.ago }
     chinchilla_memo { 'チンチラのメモ' }

--- a/backend/spec/models/care_spec.rb
+++ b/backend/spec/models/care_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Care, type: :model do
 
     context '同じのチンチラに同じcare_dayを登録したとき' do
       before { care.chinchilla_id = 1 }
-      let(:care_with_same_day) { build(:care, care_day: care.care_day, chinchilla_id: 1 ) }
+
+      let(:care_with_same_day) { build(:care, care_day: care.care_day, chinchilla_id: 1) }
 
       it '無効であること' do
         care.save
@@ -75,7 +76,7 @@ RSpec.describe Care, type: :model do
     end
 
     context 'care_weightが10000であるとき' do
-      before { care.care_weight = 10000 }
+      before { care.care_weight = 10_000 }
 
       it '無効であること' do
         expect(care).to be_invalid

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -74,5 +74,4 @@ RSpec.configure do |config|
 
   # devise_token_auth用の自作ヘルパーメソッド
   config.include RequestHelper, type: :request
-
 end

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe '/api/v1/cares', type: :request do
   let!(:chinchilla) { create(:chinchilla, user: user) }
 
   # JSONデータの中身を確認するためのkeyの配列
-  let(:my_chinchillas_keys) { ['chinchilla_name', 'chinchilla_image'] }
-  let(:chinchilla_keys) { ['chinchilla_name', 'chinchilla_sex', 'chinchilla_birthday', 'chinchilla_met_day', 'chinchilla_memo', 'chinchilla_image'] }
-
-  # ヘルパーモジュールのサインインメソッドを使用
-  before do
-    @headers = sign_in(user)
+  let(:my_chinchillas_keys) { %w[chinchilla_name chinchilla_image] }
+  let(:chinchilla_keys) do
+    %w[chinchilla_name chinchilla_sex chinchilla_birthday chinchilla_met_day chinchilla_memo chinchilla_image]
   end
 
-  # 無効なヘッダー情報用
   before do
+    # ヘルパーモジュールのサインインメソッドを使用
+    @headers = sign_in(user)
+
+    # 無効なヘッダー情報用
     @error_headers = {
       'uid' => 'error@example.com',
       'client' => 'error_client',
@@ -41,8 +41,7 @@ RSpec.describe '/api/v1/cares', type: :request do
         expect(json_response.first.keys).to contain_exactly('id', 'care_day', 'care_food', 'care_toilet', 'care_bath',
                                                             'care_play', 'care_weight', 'care_temperature',
                                                             'care_humidity', 'care_memo', 'care_image1', 'care_image2',
-                                                            'care_image3' , 'chinchilla_id', 'created_at', 'updated_at'
-                                                            )
+                                                            'care_image3', 'chinchilla_id', 'created_at', 'updated_at')
       end
     end
 
@@ -69,9 +68,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
   describe 'GET /api/v1/weight_cares' do
     let!(:care1) { create(:care, chinchilla: chinchilla, care_day: 1.day.ago, care_weight: 500) }
-    let!(:care2) { create(:care, chinchilla: chinchilla, care_day: 10.day.ago, care_weight: 550) }
-    let!(:care3) { create(:care, chinchilla: chinchilla, care_day: 5.day.ago, care_weight: 450) }
-    let!(:care4) { create(:care, chinchilla: chinchilla, care_day: 20.day.ago, care_weight: 400) }
+    let!(:care2) { create(:care, chinchilla: chinchilla, care_day: 10.days.ago, care_weight: 550) }
+    let!(:care3) { create(:care, chinchilla: chinchilla, care_day: 5.days.ago, care_weight: 450) }
+    let!(:care4) { create(:care, chinchilla: chinchilla, care_day: 20.days.ago, care_weight: 400) }
 
     context '正しいパラメーターでリクエストしたとき' do
       before do
@@ -91,7 +90,7 @@ RSpec.describe '/api/v1/cares', type: :request do
       it '配列の並び順がcare_dayの昇順であること' do
         json_response = JSON.parse(response.body)
         expect(json_response.map { |care| care['care_day'] })
-        .to eq([care4, care2, care3, care1].map { |care| care.care_day.to_s } )
+          .to eq([care4, care2, care3, care1].map { |care| care.care_day.to_s })
       end
     end
 
@@ -123,9 +122,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースにレコードが追加されること' do
-        expect {
+        expect do
           post '/api/v1/cares', params: valid_params, headers: @headers
-        }.to change(Care, :count).by(1)
+        end.to change(Care, :count).by(1)
       end
 
       it 'ステータスコード201が返ってくること' do
@@ -136,10 +135,10 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context 'care_dayを無効な値でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/cares', params: invalid_care_day_params, headers: @headers
-        }.not_to change(Care, :count)
-    end
+        end.not_to change(Care, :count)
+      end
 
       it 'ステータスコード422が返ってくること' do
         post '/api/v1/cares', params: invalid_care_day_params, headers: @headers
@@ -149,10 +148,10 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context 'care_foodを無効な値でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/cares', params: invalid_care_food_params, headers: @headers
-        }.not_to change(Care, :count)
-    end
+        end.not_to change(Care, :count)
+      end
 
       it 'ステータスコード422が返ってくること' do
         post '/api/v1/cares', params: invalid_care_food_params, headers: @headers
@@ -162,9 +161,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-          expect {
-            post '/api/v1/cares', params: valid_params
-          }.not_to change(Care, :count)
+        expect do
+          post '/api/v1/cares', params: valid_params
+        end.not_to change(Care, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -175,9 +174,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-          expect {
-            post '/api/v1/cares', params: valid_params, headers: @error_headers
-          }.not_to change(Care, :count)
+        expect do
+          post '/api/v1/cares', params: valid_params, headers: @error_headers
+        end.not_to change(Care, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -248,9 +247,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースのレコードが削除されること' do
-        expect {
-        delete "/api/v1/cares/#{care.id}", headers: @headers
-        }.to change(Care, :count).by(-1)
+        expect do
+          delete "/api/v1/cares/#{care.id}", headers: @headers
+        end.to change(Care, :count).by(-1)
       end
 
       it 'ステータスコード204が返ってくること' do
@@ -261,9 +260,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
-        expect {
-        delete "/api/v1/cares/#{care.id}"
-        }.not_to change(Care, :count)
+        expect do
+          delete "/api/v1/cares/#{care.id}"
+        end.not_to change(Care, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -274,9 +273,9 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
-        expect {
-        delete "/api/v1/cares/#{care.id}", headers: @error_headers
-        }.not_to change(Care, :count)
+        expect do
+          delete "/api/v1/cares/#{care.id}", headers: @error_headers
+        end.not_to change(Care, :count)
       end
 
       it 'ステータスコード401が返ってくること' do

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -5,21 +5,19 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
   let!(:other_user) { create(:user) }
 
   # JSONデータの中身を確認するためのkeyの配列
-  let(:my_chinchillas_keys) { ['chinchilla_name', 'chinchilla_image'] }
-  let(:chinchilla_keys) { ['chinchilla_name', 'chinchilla_sex', 'chinchilla_birthday', 'chinchilla_met_day', 'chinchilla_memo', 'chinchilla_image'] }
+  let(:my_chinchillas_keys) { %w[chinchilla_name chinchilla_image] }
+  let(:chinchilla_keys) do
+    %w[chinchilla_name chinchilla_sex chinchilla_birthday chinchilla_met_day chinchilla_memo chinchilla_image]
+  end
 
-  # ヘルパーモジュールのサインインメソッドを使用
   before do
+    # ヘルパーモジュールのサインインメソッドを使用
     @headers = sign_in(user)
-  end
 
-  # 他のユーザー情報用
-  before do
+    # 他のユーザー情報用
     @other_headers = sign_in(other_user)
-  end
 
-  # 無効なヘッダー情報用
-  before do
+    # 無効なヘッダー情報用
     @error_headers = {
       'uid' => 'error@example.com',
       'client' => 'error_client',
@@ -142,14 +140,18 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
   describe 'POST /api/v1/chinchillas' do
     let(:valid_params) { { chinchilla: attributes_for(:chinchilla) } }
-    let(:invalid_chinchilla_name_params) { { chinchilla: attributes_for(:chinchilla, chinchilla_name: '') } }
-    let(:invalid_chinchilla_sex_params) { { chinchilla: attributes_for(:chinchilla, chinchilla_sex: '男の子') } }
+    let(:invalid_chinchilla_name_params) do
+      { chinchilla: attributes_for(:chinchilla, chinchilla_name: '') }
+    end
+    let(:invalid_chinchilla_sex_params) do
+      { chinchilla: attributes_for(:chinchilla, chinchilla_sex: '男の子') }
+    end
 
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースにレコードが追加されること' do
-        expect {
+        expect do
           post '/api/v1/chinchillas', params: valid_params, headers: @headers
-        }.to change(Chinchilla, :count).by(1)
+        end.to change(Chinchilla, :count).by(1)
       end
 
       it 'ステータスコード201が返ってくること' do
@@ -160,9 +162,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context 'chinchilla_nameを無効な値でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/chinchillas', params: invalid_chinchilla_name_params, headers: @headers
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード422が返ってくること' do
@@ -173,9 +175,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context 'chinchilla_sexを無効な値でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/chinchillas', params: invalid_chinchilla_sex_params, headers: @headers
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード422が返ってくること' do
@@ -186,9 +188,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/chinchillas', params: valid_params
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -199,9 +201,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースにレコードが追加されないこと' do
-        expect {
+        expect do
           post '/api/v1/chinchillas', params: valid_params, headers: @error_headers
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -307,9 +309,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースのレコードが削除されること' do
-        expect {
+        expect do
           delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @headers
-        }.to change(Chinchilla, :count).by(-1)
+        end.to change(Chinchilla, :count).by(-1)
       end
 
       it 'ステータスコード204が返ってくること' do
@@ -330,9 +332,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context 'ログイン中の他のユーザーがリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
-        expect {
+        expect do
           delete "/api/v1/chinchillas/#{chinchilla.id}"
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード404が返ってくること' do
@@ -343,9 +345,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
-        expect {
+        expect do
           delete "/api/v1/chinchillas/#{chinchilla.id}"
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -356,9 +358,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
-        expect {
+        expect do
           delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @error_headers
-        }.not_to change(Chinchilla, :count)
+        end.not_to change(Chinchilla, :count)
       end
 
       it 'ステータスコード401が返ってくること' do


### PR DESCRIPTION
# 説明
以下のとおりRubocop Rspecを利用してテストコードを修正しました。

### 修正前：
- `/spec`ディレクトリにおいて、Rubocopによるフォーマット及びコード整形が行われていない。

### 修正後：
- Rubocop Rspecをインストールし、`/spec`ディレクトリのフォーマット及びコード整形を行いました。

### 修正理由：
- コードの可読性・保守性の向上のため。

## 実装概要
- Rubocop Rspecをインストール 774f6c0
- Rubocopによる自動修正 e67a123
- Rubocopの設定を修正 a131621


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
