### PR TITLE
chinchillas,caresコントローラー及びテストコードの追加・修正

### DIFF
--- a/backend/app/controllers/api/v1/cares_controller.rb
+++ b/backend/app/controllers/api/v1/cares_controller.rb
@@ -2,26 +2,31 @@ class Api::V1::CaresController < ApplicationController
   # ログイン状態の確認
   before_action :authenticate_api_v1_user!
 
+  # ログイン中のユーザー所有のデータか確認
+  before_action :set_chinchilla_for_get, only: %i[all_cares weight_cares]
+  before_action :set_chinchilla_for_post, only: [:create]
+  before_action :set_care, only: %i[update destroy]
+
   # ステータスコード404の共通処理
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   # お世話記録 一覧
   def all_cares
-    cares = Care.where(chinchilla_id: params[:chinchilla_id])
+    cares = @chinchilla.cares
     render json: cares, status: :ok
   end
 
   # 体重 一覧（nullを除いて日付の古い順）
   def weight_cares
-    cares = Care.where(chinchilla_id: params[:chinchilla_id])
-                .where.not(care_weight: nil)
-                .order(:care_day)
+    cares = @chinchilla.cares
+                       .where.not(care_weight: nil)
+                       .order(:care_day)
     render json: cares.as_json(only: %w[care_day care_weight]), status: :ok
   end
 
   # お世話記録 作成
   def create
-    care = Care.new(create_care_params)
+    care = @chinchilla.cares.new(create_care_params)
 
     if care.save
       # 成功した場合、ステータス201を返す
@@ -34,10 +39,9 @@ class Api::V1::CaresController < ApplicationController
 
   # お世話記録 更新
   def update
-    care = Care.find(params[:id])
-    if care.update(update_care_params)
+    if @care.update(update_care_params)
       # 成功した場合、ステータス200を返す
-      render json: care, status: :ok
+      render json: @care, status: :ok
     else
       # エラー文を取得し、ステータス422を返す
       render json: { errors: ['お世話の記録の更新に失敗しました'] }, status: :unprocessable_entity
@@ -46,8 +50,7 @@ class Api::V1::CaresController < ApplicationController
 
   # お世話記録 削除
   def destroy
-    care = Care.find(params[:id])
-    care.destroy
+    @care.destroy
     head :no_content
   end
 
@@ -71,7 +74,29 @@ class Api::V1::CaresController < ApplicationController
     )
   end
 
+  def set_chinchilla_for_get
+    # chinchilla_idはクエリパラメータとして送信されるので、params[:chinchilla_id]
+    @chinchilla = current_api_v1_user.chinchillas.find_by(id: params[:chinchilla_id])
+    record_not_found unless @chinchilla
+  end
+
+  def set_chinchilla_for_post
+    # chinchilla_idはリクエストボディに含まれて送信されるので、params[:care][:chinchilla_id]
+    @chinchilla = current_api_v1_user.chinchillas.find_by(id: params[:care][:chinchilla_id])
+    chinchilla_not_found unless @chinchilla
+  end
+
+  def set_care
+    care = Care.find_by(id: params[:id])
+    record_not_found unless care && current_api_v1_user.chinchillas.exists?(care.chinchilla_id)
+    @care = care
+  end
+
   def record_not_found
     render json: { errors: ['指定されたお世話の記録が見つかりませんでした'] }, status: :not_found
+  end
+
+  def chinchilla_not_found
+    render json: { errors: ['指定されたチンチラが見つかりませんでした'] }, status: :not_found
   end
 end

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -221,6 +221,16 @@ RSpec.describe '/api/v1/cares', type: :request do
       end
     end
 
+    context '指定したレコードが存在しないとき' do
+      before do
+        put '/api/v1/cares/0', params: valid_update_params, headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context '非ログイン状態のユーザーがリクエストしたとき' do
       before do
         put "/api/v1/cares/#{care.id}", params: valid_update_params
@@ -265,6 +275,16 @@ RSpec.describe '/api/v1/cares', type: :request do
       it 'ステータスコード204が返ってくること' do
         delete "/api/v1/cares/#{care.id}", headers: @headers
         expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context '指定したレコードが存在しないとき' do
+      before do
+        delete '/api/v1/cares/0', headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe '/api/v1/cares', type: :request do
       end
     end
 
+    context '指定したchinchilla_idが存在しないとき' do
+      before do
+        get '/api/v1/all_cares?chinchilla_id=0', headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'ログイン中の他のユーザーがリクエストしたとき' do
       before do
         get "/api/v1/all_cares?chinchilla_id=#{chinchilla.id}", headers: @other_headers
@@ -156,6 +166,16 @@ RSpec.describe '/api/v1/cares', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response).to be_an_instance_of(Array)
         expect(json_response).to be_empty
+      end
+    end
+
+    context '指定したchinchilla_idが存在しないとき' do
+      before do
+        get '/api/v1/weight_cares?chinchilla_id=0', headers: @headers
+      end
+
+      it 'ステータスコード404が返ってくること' do
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -223,7 +223,12 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '非ログイン状態のユーザーがリクエストしたとき' do
       before do
-        put "/api/v1/cares/#{care.id}"
+        put "/api/v1/cares/#{care.id}", params: valid_update_params
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        care.reload
+        expect(care.care_memo).not_to eq('アップデート')
       end
 
       it 'ステータスコード401が返ってくること' do
@@ -233,7 +238,12 @@ RSpec.describe '/api/v1/cares', type: :request do
 
     context '誤ったトークン情報でリクエストしたとき' do
       before do
-        put "/api/v1/cares/#{care.id}", headers: @error_headers
+        put "/api/v1/cares/#{care.id}", params: valid_update_params, headers: @error_headers
+      end
+
+      it 'リクエストがあったレコードが更新されていないこと' do
+        care.reload
+        expect(care.care_memo).not_to eq('アップデート')
       end
 
       it 'ステータスコード401が返ってくること' do

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe '/api/v1/cares', type: :request do
   # メインユーザー
   let!(:user) { create(:user) }
   let!(:chinchilla) { create(:chinchilla, user: user) }
+  let!(:no_care_chinchilla) { create(:chinchilla, user: user) }
 
   # 他のユーザー
   let!(:other_user) { create(:user) }
@@ -60,9 +61,9 @@ RSpec.describe '/api/v1/cares', type: :request do
       end
     end
 
-    context '指定したchinchilla_idが存在しないとき' do
+    context 'レコードが存在しないとき' do
       before do
-        get '/api/v1/all_cares?chinchilla_id=0', headers: @headers
+        get "/api/v1/all_cares?chinchilla_id=#{no_care_chinchilla.id}", headers: @headers
       end
 
       it 'ステータスコード200が返ってくること' do
@@ -142,14 +143,21 @@ RSpec.describe '/api/v1/cares', type: :request do
       end
     end
 
-    context '指定したchinchilla_idが存在しないとき' do
+    context 'レコードが存在しないとき' do
       before do
-        get '/api/v1/weight_cares?chinchilla_id=0', headers: @headers
+        get "/api/v1/all_cares?chinchilla_id=#{no_care_chinchilla.id}", headers: @headers
       end
 
       it 'ステータスコード200が返ってくること' do
         expect(response).to have_http_status(:ok)
       end
+
+      it '配列が空であること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response).to be_empty
+      end
+    end
 
     context 'ログイン中の他のユーザーがリクエストしたとき' do
       before do

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe '/api/v1/cares', type: :request do
       end
     end
 
+    context '指定したchinchilla_idが存在しないとき' do
+      before do
+        get '/api/v1/all_cares?chinchilla_id=0', headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '配列が空であること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response).to be_empty
+      end
+    end
+
     context '非ログイン状態のユーザーがリクエストしたとき' do
       before do
         get "/api/v1/all_cares?chinchilla_id=#{chinchilla.id}"
@@ -91,6 +107,22 @@ RSpec.describe '/api/v1/cares', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response.map { |care| care['care_day'] })
           .to eq([care4, care2, care3, care1].map { |care| care.care_day.to_s })
+      end
+    end
+
+    context '指定したchinchilla_idが存在しないとき' do
+      before do
+        get '/api/v1/weight_cares?chinchilla_id=0', headers: @headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '配列が空であること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response).to be_empty
       end
     end
 

--- a/backend/spec/requests/api/v1/cares_spec.rb
+++ b/backend/spec/requests/api/v1/cares_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe '/api/v1/cares', type: :request do
 
   describe 'POST /api/v1/cares' do
     let(:valid_params) { { care: attributes_for(:care, chinchilla_id: chinchilla.id) } }
-    let(:invalid_care_day_params) { { care: attributes_for(:care, care_day: '') } }
-    let(:invalid_care_food_params) { { care: attributes_for(:care, care_food: '普通') } }
+    let(:invalid_care_day_params) { { care: attributes_for(:care, care_day: '', chinchilla_id: chinchilla.id) } }
+    let(:invalid_care_food_params) { { care: attributes_for(:care, care_food: '普通', chinchilla_id: chinchilla.id) } }
 
     context '正しいパラメーターでリクエストしたとき' do
       it 'データベースにレコードが追加されること' do

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -115,9 +115,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
       end
     end
 
-    context 'ログイン中の他のユーザーがリクエストしたとき' do
+    context '指定したレコードが存在しないとき' do
       before do
-        get "/api/v1/chinchillas/#{chinchilla.id}", headers: @other_headers
+        get '/api/v1/chinchillas/0', headers: @headers
       end
 
       it 'ステータスコード404が返ってくること' do
@@ -125,9 +125,9 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
       end
     end
 
-    context '指定したレコードが存在しないとき' do
+    context 'ログイン中の他のユーザーがリクエストしたとき' do
       before do
-        get '/api/v1/chinchillas/0', headers: @headers
+        get "/api/v1/chinchillas/#{chinchilla.id}", headers: @other_headers
       end
 
       it 'ステータスコード404が返ってくること' do

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     context '指定したレコードが存在しないとき' do
       before do
-        put '/api/v1/chinchillas/0', params: invalid_update_params, headers: @headers
+        put '/api/v1/chinchillas/0', params: valid_update_params, headers: @headers
       end
 
       it 'ステータスコード404が返ってくること' do
@@ -351,7 +351,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
     context 'ログイン中の他のユーザーがリクエストしたとき' do
       it 'データベースのレコードが削除されないこと' do
         expect do
-          delete "/api/v1/chinchillas/#{chinchilla.id}"
+          delete "/api/v1/chinchillas/#{chinchilla.id}", headers: @otheer_headers
         end.not_to change(Chinchilla, :count)
       end
 

--- a/backend/spec/requests/api/v1/chinchillas_spec.rb
+++ b/backend/spec/requests/api/v1/chinchillas_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe '/api/v1/chinchillas', type: :request do
   let!(:user) { create(:user) }
   let!(:other_user) { create(:user) }
+  let!(:no_chinchilla_user) { create(:user) }
 
   # JSONデータの中身を確認するためのkeyの配列
   let(:my_chinchillas_keys) { %w[chinchilla_name chinchilla_image] }
@@ -16,6 +17,7 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
 
     # 他のユーザー情報用
     @other_headers = sign_in(other_user)
+    @no_chinchilla_headers = sign_in(no_chinchilla_user)
 
     # 無効なヘッダー情報用
     @error_headers = {
@@ -48,6 +50,22 @@ RSpec.describe '/api/v1/chinchillas', type: :request do
         json_response = JSON.parse(response.body)
         chinchilla_ids = json_response.map { |chinchillas| chinchillas['id'] }
         expect(chinchilla_ids).not_to include(other_chinchilla.id)
+      end
+    end
+
+    context 'レコードが存在しないとき' do
+      before do
+        get '/api/v1/my_chinchillas', headers: @no_chinchilla_headers
+      end
+
+      it 'ステータスコード200が返ってくること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '配列が空であること' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_an_instance_of(Array)
+        expect(json_response).to be_empty
       end
     end
 


### PR DESCRIPTION
# 説明
以下のとおりchinchillas,caresコントローラー及びテストコードを追加・修正しました。


### 修正前：
- caresコントローラーのupdateアクションについて、非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合において、レコードが更新されないことを確認するテストがない。
- caresコントローラーのall_cares / weight_cares / update / destroyアクションについて、存在しないid / chinchilla_idを指定してリクエストを行った場合のテストがない。
- chinchillas,caresコントローラーのmy_chinchillas / all_cares / weight_caresアクションについて、空の配列が返される場合のテストがない。
- caresコントローラーについて、ログイン中のユーザーであれば、他のユーザーが所有するCareモデルに関するレコードを操作できる。

### 修正後：
- 非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合に、レコードが更新されないことを確認するテストコードを追加しました。
- 存在しないid / chinchilla_idを指定してリクエストを行った場合のテストコードを追加しました。
- 空の配列が返される場合のテストコードを追加しました。
- ログイン中のユーザーが所有するデータのみ操作できるように修正しました。

### 修正理由：
- 実装の正しさを保証するため。
- 予期せぬバグを防ぐため。

## 実装概要
- 非ログイン中のユーザーや誤ったトークン情報でリクエストを行った場合に関するテストコードを追加 478200a
- 存在しないid / chinchilla_idを指定してリクエストを行った場合に関するテストコードを追加 0b093f7
- 空の配列が返される場合のテストコードを追加・修正 7595c6d 4ffe324
- caresコントローラーの修正 acc20ea
- 他のユーザーによるレコード操作に関するテストコードの追加・修正 030a083 b094d3c
- その他の修正 d6ddeec 48bbac9 e6a1c50

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
