### PR TITLE
TypeScriptに移行 #5

### DIFF
--- a/frontend/src/components/pages/chinchilla-registration/index.tsx
+++ b/frontend/src/components/pages/chinchilla-registration/index.tsx
@@ -24,7 +24,7 @@ export const ChinchillaRegistrationPage = () => {
   // 選択中のチンチラの状態管理（グローバル）
   const { setChinchillaId, setHeaderName, setHeaderImage } = useContext(SelectedChinchillaIdContext)
 
-  const [chinchillaImage, setChinchillaImage] = useState<File | null>(null)
+  const [chinchillaImageFile, setChinchillaImageFile] = useState<File | null>(null)
   const chinchillaMemo: string = ''
 
   const {
@@ -66,16 +66,16 @@ export const ChinchillaRegistrationPage = () => {
     e.currentTarget.value = ''
 
     // データ更新用
-    setChinchillaImage(file)
+    setChinchillaImageFile(file)
   }, [])
 
   // FormData形式でデータを作成
   const createFormData = (data: RhfCreateChinchillaType) => {
     const formData = new FormData()
 
-    // chinchillaImageがnullでないことを確認
-    if (chinchillaImage) {
-      formData.append('chinchilla[chinchillaImage]', chinchillaImage)
+    // chinchillaImageFileがnullでないことを確認
+    if (chinchillaImageFile) {
+      formData.append('chinchilla[chinchillaImage]', chinchillaImageFile)
     }
     formData.append('chinchilla[chinchillaName]', data.chinchillaName)
     formData.append('chinchilla[chinchillaSex]', data.chinchillaSex)

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.tsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/displayChinchillaProfileItem.tsx
@@ -1,4 +1,8 @@
-export const DisplayChinchillaProfileItem = ({ label, value }) => {
+type Props = { label: string; value: string }
+
+export const DisplayChinchillaProfileItem = (props: Props) => {
+  const { label, value } = props
+
   return (
     <div className="mx-5 mt-5 flex border-b border-solid border-b-light-black pb-2 sm:mx-10">
       <p className="w-20 text-center text-sm text-dark-black sm:w-28 sm:text-base">{label}</p>

--- a/frontend/src/components/pages/mychinchilla/myChinchillaList.tsx
+++ b/frontend/src/components/pages/mychinchilla/myChinchillaList.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { useMyChinchillas } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
-import type { MyChinchilla } from 'src/types/chinchilla'
+import type { MyChinchillaType } from 'src/types/chinchilla'
 
 export const MyChinchillaList = () => {
   const { chinchillas } = useMyChinchillas()
@@ -16,7 +16,7 @@ export const MyChinchillaList = () => {
           chinchillas.length === 1 ? 'place-items-center' : 'gap-y-10 sm:grid-cols-2 sm:gap-x-20'
         }`}
       >
-        {chinchillas.map((chinchilla: MyChinchilla) => (
+        {chinchillas.map((chinchilla: MyChinchillaType) => (
           <div key={chinchilla.id}>
             <Link
               href="/mychinchilla/chinchilla-profile"

--- a/frontend/src/components/pages/mypage/index.tsx
+++ b/frontend/src/components/pages/mypage/index.tsx
@@ -55,11 +55,11 @@ export const MyPagePage = () => {
         Cookies.remove('_uid')
 
         router.push('/signin')
-        setIsSignedIn(false)
-        setCurrentUser(null)
-        setProcessUser(null)
+        setIsSignedIn(undefined)
+        setCurrentUser(undefined)
+        setProcessUser(undefined)
         setChinchillaId(0)
-        setHeaderName('')
+        setHeaderName(undefined)
         setHeaderImage({ url: '' })
         debugLog('ログアウト:', '成功')
       } else {

--- a/frontend/src/components/pages/mypage/index.tsx
+++ b/frontend/src/components/pages/mypage/index.tsx
@@ -60,7 +60,7 @@ export const MyPagePage = () => {
         setProcessUser(null)
         setChinchillaId(0)
         setHeaderName('')
-        setHeaderImage('')
+        setHeaderImage({ url: '' })
         debugLog('ログアウト:', '成功')
       } else {
         debugLog('ログアウト:', '失敗')

--- a/frontend/src/components/shared/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/shared/DeleteConfirmationModal.tsx
@@ -1,6 +1,14 @@
+import { Dispatch, SetStateAction } from 'react'
 import { Button } from 'src/components/shared/Button'
 
-export const DeleteConfirmationModal = ({ setIsModalOpen, handleDelete }) => {
+type Props = {
+  setIsModalOpen: Dispatch<SetStateAction<boolean>>
+  handleDelete: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>
+}
+
+export const DeleteConfirmationModal = (props: Props) => {
+  const { setIsModalOpen, handleDelete } = props
+
   return (
     <>
       {/* 削除確認モーダル */}
@@ -9,13 +17,13 @@ export const DeleteConfirmationModal = ({ setIsModalOpen, handleDelete }) => {
           <p className="text-lg text-dark-black">本当に削除しますか？</p>
           <div className="mt-8 flex">
             <Button
-              type="button"
+              btnType="button"
               click={() => setIsModalOpen(false)}
               addStyle="btn-ghost bg-gray-200 w-32 h-14 mr-5"
             >
               キャンセル
             </Button>
-            <Button type="submit" click={handleDelete} addStyle="btn-secondary h-14 w-32">
+            <Button btnType="submit" click={handleDelete} addStyle="btn-secondary h-14 w-32">
               削除
             </Button>
           </div>

--- a/frontend/src/components/shared/DisplayMemo.tsx
+++ b/frontend/src/components/shared/DisplayMemo.tsx
@@ -1,7 +1,11 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFilePen } from '@fortawesome/free-solid-svg-icons'
 
-export const DisplayMemo = ({ contents }) => {
+type Props = { contents: string }
+
+export const DisplayMemo = (props: Props) => {
+  const { contents } = props
+
   return (
     <div>
       <div className="flex px-1 py-2">

--- a/frontend/src/components/shared/Header/DisplaySelectChinchilla.tsx
+++ b/frontend/src/components/shared/Header/DisplaySelectChinchilla.tsx
@@ -1,12 +1,16 @@
+import { Dispatch, SetStateAction } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHandPointer } from '@fortawesome/free-solid-svg-icons'
 
-export const DisplaySelectChinchilla = ({
-  headerName,
-  headerImage,
-  handleFetch,
-  setIsModalOpen
-}) => {
+type Props = {
+  headerName: string
+  headerImage: { url: string }
+  handleFetch: () => Promise<void>
+  setIsModalOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export const DisplaySelectChinchilla = (props: Props) => {
+  const { headerName, headerImage, handleFetch, setIsModalOpen } = props
   return (
     <>
       {/* 選択中のチンチラ */}

--- a/frontend/src/components/shared/Header/DisplaySelectChinchilla.tsx
+++ b/frontend/src/components/shared/Header/DisplaySelectChinchilla.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHandPointer } from '@fortawesome/free-solid-svg-icons'
 
 type Props = {
-  headerName: string
+  headerName: string | undefined
   headerImage: { url: string }
   handleFetch: () => Promise<void>
   setIsModalOpen: Dispatch<SetStateAction<boolean>>
@@ -11,37 +11,39 @@ type Props = {
 
 export const DisplaySelectChinchilla = (props: Props) => {
   const { headerName, headerImage, handleFetch, setIsModalOpen } = props
-  return (
-    <>
-      {/* 選択中のチンチラ */}
-      <button
-        type="button"
-        onClick={() => {
-          handleFetch()
-          setIsModalOpen(true)
-        }}
-        className="flex items-center px-3"
-      >
-        {/* チンチラが選択されている場合は画像を表示 */}
-        {headerName && (
-          <img
-            src={headerImage?.url ? headerImage.url : '/images/default.svg'}
-            width="40"
-            height="40"
-            alt="プロフィール画像"
-            className="mr-1 h-10 w-10 rounded-[50%] border border-solid border-ligth-white bg-ligth-white"
-          />
-        )}
 
-        {/* チンチラが選択されている場合は名前を表示する */}
-        {/* 未選択の場合は「チンチラを選択」を表示 */}
-        <p className="text-base text-ligth-white transition-colors duration-200 hover:text-slate-200">
-          {headerName ? headerName : 'チンチラを選択'}
-          {!headerName && (
-            <FontAwesomeIcon icon={faHandPointer} className="ml-1 text-ligth-white" />
+  if (typeof headerName === 'string')
+    return (
+      <>
+        {/* 選択中のチンチラ */}
+        <button
+          type="button"
+          onClick={() => {
+            handleFetch()
+            setIsModalOpen(true)
+          }}
+          className="flex items-center px-3"
+        >
+          {/* チンチラが選択されている場合は画像を表示 */}
+          {headerName && (
+            <img
+              src={headerImage?.url ? headerImage.url : '/images/default.svg'}
+              width="40"
+              height="40"
+              alt="プロフィール画像"
+              className="mr-1 h-10 w-10 rounded-[50%] border border-solid border-ligth-white bg-ligth-white"
+            />
           )}
-        </p>
-      </button>
-    </>
-  )
+
+          {/* チンチラが選択されている場合は名前を表示する */}
+          {/* 未選択の場合は「チンチラを選択」を表示 */}
+          <p className="text-base text-ligth-white transition-colors duration-200 hover:text-slate-200">
+            {headerName ? headerName : 'チンチラを選択'}
+            {!headerName && (
+              <FontAwesomeIcon icon={faHandPointer} className="ml-1 text-ligth-white" />
+            )}
+          </p>
+        </button>
+      </>
+    )
 }

--- a/frontend/src/components/shared/Header/index.tsx
+++ b/frontend/src/components/shared/Header/index.tsx
@@ -13,10 +13,10 @@ import { faCircleUser } from '@fortawesome/free-solid-svg-icons'
 
 import { debugLog } from 'src/lib/debug/debugLog'
 
-import type { MyChinchilla } from 'src/types/chinchilla'
+import type { MyChinchillaType } from 'src/types/chinchilla'
 
 export const Header = () => {
-  const [allChinchillas, setAllChinchillas] = useState<MyChinchilla[]>([])
+  const [allChinchillas, setAllChinchillas] = useState<MyChinchillaType[]>([])
 
   //ログインユーザーの状態管理（グローバル）
   const { isSignedIn, currentUser } = useContext(AuthContext)
@@ -51,7 +51,7 @@ export const Header = () => {
   // チンチラを選択
   const handleSelectChinchilla = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedChinchilla = allChinchillas.filter(
-      (chinchilla: MyChinchilla) => chinchilla.id === Number(e.target.value)
+      (chinchilla: MyChinchillaType) => chinchilla.id === Number(e.target.value)
     )
     debugLog('選択中のチンチラ:', selectedChinchilla)
 

--- a/frontend/src/components/shared/Header/index.tsx
+++ b/frontend/src/components/shared/Header/index.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState, useEffect } from 'react'
 import Link from 'next/link'
+import { AxiosResponse } from 'axios'
 import { AuthContext } from 'src/contexts/auth'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 import { getMyChinchillas } from 'src/lib/api/chinchilla'
@@ -12,8 +13,10 @@ import { faCircleUser } from '@fortawesome/free-solid-svg-icons'
 
 import { debugLog } from 'src/lib/debug/debugLog'
 
+import type { MyChinchilla } from 'src/types/chinchilla'
+
 export const Header = () => {
-  const [allChinchillas, setAllChinchillas] = useState([])
+  const [allChinchillas, setAllChinchillas] = useState<MyChinchilla[]>([])
 
   //ログインユーザーの状態管理（グローバル）
   const { isSignedIn, currentUser } = useContext(AuthContext)
@@ -39,28 +42,33 @@ export const Header = () => {
 
   // モーダルを開いた時に全てのチンチラのデータを取得
   const handleFetch = async () => {
-    const res = await getMyChinchillas()
+    const response = await getMyChinchillas()
+    const res = response as AxiosResponse
     debugLog('マイチンチラ:', res.data)
     setAllChinchillas(res.data)
   }
 
   // チンチラを選択
-  const handleSelectChinchilla = (e) => {
+  const handleSelectChinchilla = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedChinchilla = allChinchillas.filter(
-      (chinchilla) => chinchilla.id === Number(e.target.value)
+      (chinchilla: MyChinchilla) => chinchilla.id === Number(e.target.value)
     )
     debugLog('選択中のチンチラ:', selectedChinchilla)
-    setChinchillaId(selectedChinchilla[0].id)
-    setHeaderName(selectedChinchilla[0].chinchillaName)
-    setHeaderImage(selectedChinchilla[0].chinchillaImage)
-    setIsModalOpen(false)
+
+    if (selectedChinchilla.length > 0) {
+      setChinchillaId(selectedChinchilla[0].id)
+      setHeaderName(selectedChinchilla[0].chinchillaName)
+      setHeaderImage(selectedChinchilla[0].chinchillaImage)
+      setIsModalOpen(false)
+    }
   }
 
   // チンチラが登録されている場合は、先頭のチンチラをセット
   const fetch = async () => {
     if (currentUser) {
       try {
-        const res = await getMyChinchillas()
+        const response = await getMyChinchillas()
+        const res = response as AxiosResponse
         if (res.data.length !== 0) {
           setChinchillaId(res.data[0].id)
           setHeaderName(res.data[0].chinchillaName)

--- a/frontend/src/components/shared/Header/index.tsx
+++ b/frontend/src/components/shared/Header/index.tsx
@@ -96,7 +96,7 @@ export const Header = () => {
               width="100"
               height="48"
               alt="サービス名"
-              className={` my-2 ml-2 ${isSignedIn && currentUser && 'hidden sm:block'}`}
+              className={`my-2 ml-2 ${isSignedIn === true && currentUser && 'hidden sm:block'}`}
             />
           </div>
         </Link>

--- a/frontend/src/components/shared/Header/selectChinchillaModal.tsx
+++ b/frontend/src/components/shared/Header/selectChinchillaModal.tsx
@@ -1,13 +1,13 @@
 import { Dispatch, SetStateAction } from 'react'
 import { Button } from 'src/components/shared/Button'
 
-import type { MyChinchilla } from 'src/types/chinchilla'
+import type { MyChinchillaType } from 'src/types/chinchilla'
 
 type Props = {
   chinchillaId: number
   handleSelectChinchilla: (e: React.ChangeEvent<HTMLSelectElement>) => void
   headerDisabled: boolean
-  allChinchillas: MyChinchilla[]
+  allChinchillas: MyChinchillaType[]
   setIsModalOpen: Dispatch<SetStateAction<boolean>>
 }
 

--- a/frontend/src/components/shared/Header/selectChinchillaModal.tsx
+++ b/frontend/src/components/shared/Header/selectChinchillaModal.tsx
@@ -1,12 +1,20 @@
+import { Dispatch, SetStateAction } from 'react'
 import { Button } from 'src/components/shared/Button'
 
-export const SelectChinchillaModal = ({
-  chinchillaId,
-  handleSelectChinchilla,
-  headerDisabled,
-  allChinchillas,
-  setIsModalOpen
-}) => {
+import type { MyChinchilla } from 'src/types/chinchilla'
+
+type Props = {
+  chinchillaId: number
+  handleSelectChinchilla: (e: React.ChangeEvent<HTMLSelectElement>) => void
+  headerDisabled: boolean
+  allChinchillas: MyChinchilla[]
+  setIsModalOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export const SelectChinchillaModal = (props: Props) => {
+  const { chinchillaId, handleSelectChinchilla, headerDisabled, allChinchillas, setIsModalOpen } =
+    props
+
   return (
     <div className="fixed inset-0 flex h-full w-full items-center justify-center  bg-gray-400/50">
       <div className="z-10 grid w-11/12  max-w-lg place-content-center place-items-center rounded-lg bg-ligth-white px-5 py-10">
@@ -33,7 +41,7 @@ export const SelectChinchillaModal = ({
         </div>
 
         <Button
-          type="button"
+          btnType="button"
           click={() => setIsModalOpen(false)}
           addStyle="btn-ghost bg-gray-200 w-32 h-14 mt-8 py-3"
         >

--- a/frontend/src/components/shared/RhfTextareaForm.tsx
+++ b/frontend/src/components/shared/RhfTextareaForm.tsx
@@ -1,9 +1,14 @@
-import { useController } from 'react-hook-form'
+import { useController, FieldValues, UseControllerProps } from 'react-hook-form'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFilePen } from '@fortawesome/free-solid-svg-icons'
 
-export const RhfTextareaForm = ({ htmlFor, label, id, name, control }) => {
+import type { RhfTextareaFormType } from 'src/types/rhf'
+
+type TextareaItemComponentProps<T extends FieldValues> = UseControllerProps<T> & RhfTextareaFormType
+
+export const RhfTextareaForm = <T extends FieldValues>(props: TextareaItemComponentProps<T>) => {
+  const { htmlFor, label, id, name, control } = props
   const { field, fieldState } = useController({ name, control })
   const { error } = fieldState
 

--- a/frontend/src/contexts/chinchilla.tsx
+++ b/frontend/src/contexts/chinchilla.tsx
@@ -13,7 +13,7 @@ export const SelectedChinchillaIdContext = createContext<ChinchillaContextType>(
 //_app.jsにエクスポートして、全体の親にする
 export const ChinchillaProvider = ({ children }: Props) => {
   const [chinchillaId, setChinchillaId] = useState<number>(0)
-  const [headerName, setHeaderName] = useState<string>('')
+  const [headerName, setHeaderName] = useState<string | undefined>(undefined)
   const [headerImage, setHeaderImage] = useState<{ url: string }>({ url: '' })
   const [headerDisabled, setHeaderDisabled] = useState<boolean>(false)
 

--- a/frontend/src/contexts/chinchilla.tsx
+++ b/frontend/src/contexts/chinchilla.tsx
@@ -14,7 +14,7 @@ export const SelectedChinchillaIdContext = createContext<ChinchillaContextType>(
 export const ChinchillaProvider = ({ children }: Props) => {
   const [chinchillaId, setChinchillaId] = useState<number>(0)
   const [headerName, setHeaderName] = useState<string>('')
-  const [headerImage, setHeaderImage] = useState<string>('')
+  const [headerImage, setHeaderImage] = useState<{ url: string }>({ url: '' })
   const [headerDisabled, setHeaderDisabled] = useState<boolean>(false)
 
   const value = {

--- a/frontend/src/lib/api/chinchilla.ts
+++ b/frontend/src/lib/api/chinchilla.ts
@@ -46,15 +46,14 @@ export const getMyChinchillas = () => {
 }
 
 // チンチラプロフィール用
-export const getChinchilla = (chinchillaId: number) => {
-  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.get(`/chinchillas/${chinchillaId}`, {
-    headers: {
-      'access-token': Cookies.get('_access_token'),
-      client: Cookies.get('_client'),
-      uid: Cookies.get('_uid')
-    }
-  })
+export const useChinchillaProfile = (chinchillaId: number) => {
+  const { data, error, isLoading } = useSWR(`/chinchillas/${chinchillaId}`, fetchWithToken)
+
+  return {
+    chinchillaProfile: data,
+    isLoading,
+    isError: error
+  }
 }
 
 // チンチラプロフィール作成

--- a/frontend/src/types/chinchilla.ts
+++ b/frontend/src/types/chinchilla.ts
@@ -17,7 +17,7 @@ export type RhfCreateChinchillaType = {
 export type ChinchillaContextType = {
   chinchillaId: number
   setChinchillaId: (chinchillaId: number) => void
-  headerName: string
+  headerName: string | undefined
   setHeaderName: (headerName: string) => void
   headerImage: { url: string }
   setHeaderImage: (headerImage: { url: string }) => void
@@ -28,7 +28,7 @@ export type ChinchillaContextType = {
 export const defaultChinchillaContextValue = {
   chinchillaId: 0,
   setChinchillaId: () => {},
-  headerName: '',
+  headerName: undefined,
   setHeaderName: () => {},
   headerImage: { url: '' },
   setHeaderImage: () => {},

--- a/frontend/src/types/chinchilla.ts
+++ b/frontend/src/types/chinchilla.ts
@@ -19,8 +19,8 @@ export type ChinchillaContextType = {
   setChinchillaId: (chinchillaId: number) => void
   headerName: string
   setHeaderName: (headerName: string) => void
-  headerImage: string
-  setHeaderImage: (headerImage: string) => void
+  headerImage: { url: string }
+  setHeaderImage: (headerImage: { url: string }) => void
   headerDisabled: boolean
   setHeaderDisabled: (headerDisabled: boolean) => void
 }
@@ -30,7 +30,7 @@ export const defaultChinchillaContextValue = {
   setChinchillaId: () => {},
   headerName: '',
   setHeaderName: () => {},
-  headerImage: '',
+  headerImage: { url: '' },
   setHeaderImage: () => {},
   headerDisabled: false,
   setHeaderDisabled: () => {}

--- a/frontend/src/types/chinchilla.ts
+++ b/frontend/src/types/chinchilla.ts
@@ -5,12 +5,32 @@ export type MyChinchillaType = {
   chinchillaName: string
 }
 
+// チンチラプロフィール用
+export type ChinchillaProfileType = {
+  id: number
+  chinchillaImage: { url: string }
+  chinchillaName: string
+  chinchillaSex: string
+  chinchillaBirthday: string
+  chinchillaMetDay: string
+  chinchillaMemo: string
+}
+
 // Create時にRHFで受け取るもの(Image, Memo以外)
 export type RhfCreateChinchillaType = {
   chinchillaName: string
   chinchillaSex: string
   chinchillaBirthday: string
   chinchillaMetDay: string
+}
+
+// Update時にRHFで受け取るもの(Image以外)
+export type RhfUpdateChinchillaType = {
+  chinchillaName: string
+  chinchillaSex: string
+  chinchillaBirthday: string
+  chinchillaMetDay: string
+  chinchillaMemo: string
 }
 
 // チンチラの状態管理(グローバル)

--- a/frontend/src/types/chinchilla.ts
+++ b/frontend/src/types/chinchilla.ts
@@ -18,7 +18,7 @@ export type ChinchillaContextType = {
   chinchillaId: number
   setChinchillaId: (chinchillaId: number) => void
   headerName: string | undefined
-  setHeaderName: (headerName: string) => void
+  setHeaderName: (headerName: string | undefined) => void
   headerImage: { url: string }
   setHeaderImage: (headerImage: { url: string }) => void
   headerDisabled: boolean

--- a/frontend/src/types/chinchilla.ts
+++ b/frontend/src/types/chinchilla.ts
@@ -1,5 +1,5 @@
 // マイチンチラ用
-export type MyChinchilla = {
+export type MyChinchillaType = {
   id: number
   chinchillaImage: { url: string }
   chinchillaName: string

--- a/frontend/src/types/rhf.ts
+++ b/frontend/src/types/rhf.ts
@@ -11,3 +11,10 @@ export type RhfInputFormType = {
 }
 
 export type RhfRadioButtonType = { name: string }
+
+export type RhfTextareaFormType = {
+  htmlFor: string
+  label: string
+  id: string
+  name: string
+}


### PR DESCRIPTION
# 説明
以下のとおりヘッダー等をTypeScriptに移行しました。


### 修正前：
- TypeScriptが導入されておらず、型安全でない。

### 修正後：
以下をTypeScriptに移行しました。
- チンチラプロフィールページ(`/mychinchilla/chinchilla-profile`)
- ヘッダー

### 修正理由：
- フロントエンド開発を堅牢に行い、将来の機能追加や改修に備えるため。

## 実装概要
- ヘッダーをTypeScriptに移行 217c8b4
- チンチラプロフィールページをTypeScriptに移行 2b1ace0 f4a96f5 c9c0373 6edaca9
- その他の修正 179411d fe67f89 08a9bca 871228a 591288a 


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
