### PR TITLE
TypeScriptに移行 #6

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/careMemoFormItem.tsx
+++ b/frontend/src/components/pages/care-record-calendar/careMemoFormItem.tsx
@@ -1,7 +1,15 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFilePen } from '@fortawesome/free-solid-svg-icons'
 
-export const CareMemoFormItem = ({ careMemo, onChange, careMemoErrorMessage }) => {
+type Props = {
+  careMemo: string
+  handleCareMemoChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  careMemoErrorMessage: string
+}
+
+export const CareMemoFormItem = (props: Props) => {
+  const { careMemo, handleCareMemoChange, careMemoErrorMessage } = props
+
   return (
     <div className="form-control h-96 w-80 sm:h-[464px] sm:w-[500px]">
       <label htmlFor="careMemo" className="mx-1 my-2 flex">
@@ -15,7 +23,7 @@ export const CareMemoFormItem = ({ careMemo, onChange, careMemoErrorMessage }) =
         id="careMemo"
         placeholder="メモを記入してください。"
         value={careMemo}
-        onChange={onChange}
+        onChange={handleCareMemoChange}
         className="textarea textarea-primary h-80 border-dark-blue bg-ligth-white text-base text-dark-black sm:h-96"
       ></textarea>
       {careMemoErrorMessage && (

--- a/frontend/src/components/pages/care-record-calendar/displayRadioButtonItem.tsx
+++ b/frontend/src/components/pages/care-record-calendar/displayRadioButtonItem.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFaceSmileBeam, faFaceDizzy, faFaceMeh } from '@fortawesome/free-solid-svg-icons'
 
-export const DisplayRadioButtonItem = ({ label, item, value }) => {
+type Props = { label: string; item: string; value: string }
+
+export const DisplayRadioButtonItem = (props: Props) => {
+  const { label, item, value } = props
+
   return (
     <div className="mx-5 mt-3 flex items-center border-b border-solid border-b-light-black sm:mx-10 sm:mt-6">
       <p className="w-24 text-center text-sm text-dark-black sm:w-28 sm:text-base">{label}</p>

--- a/frontend/src/components/pages/care-record-calendar/inputRadioButtonItem.tsx
+++ b/frontend/src/components/pages/care-record-calendar/inputRadioButtonItem.tsx
@@ -1,10 +1,23 @@
-import React from 'react'
+import React, { Dispatch, SetStateAction } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFaceSmileBeam, faFaceDizzy, faFaceMeh } from '@fortawesome/free-solid-svg-icons'
 
-export const InputRadioButtonItem = ({ label, item, value, setValue }) => {
+type Props = {
+  label: string
+  item: string
+  value: string
+  setValue: Dispatch<SetStateAction<string>>
+}
+
+export const InputRadioButtonItem = (props: Props) => {
+  const { label, item, value, setValue } = props
+
   // ラジオボタンの取り消し
-  const handleRadioClick = (setter, currentValue, newValue) => {
+  const handleRadioClick = (
+    setter: Dispatch<SetStateAction<string>>,
+    currentValue: string,
+    newValue: string
+  ) => {
     if (currentValue === newValue) {
       return setter('')
     }

--- a/frontend/src/components/pages/care-record-calendar/numericFormItem.tsx
+++ b/frontend/src/components/pages/care-record-calendar/numericFormItem.tsx
@@ -1,20 +1,26 @@
+import { Dispatch, SetStateAction } from 'react'
 import { NumericFormat } from 'react-number-format'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 
-export const NumericFormItem = ({
-  label,
-  item,
-  inputMode,
-  value,
-  setValue,
-  min,
-  max,
-  placeholder,
-  decimalScale,
-  suffix
-}) => {
+type Props = {
+  label: string
+  item: string
+  inputMode: 'decimal' | 'numeric'
+  value: number | null
+  setValue: Dispatch<SetStateAction<number | null>>
+  min: number
+  max: number
+  placeholder: string
+  decimalScale: number
+  suffix: string
+}
+
+export const NumericFormItem = (props: Props) => {
+  const { label, item, inputMode, value, setValue, min, max, placeholder, decimalScale, suffix } =
+    props
+
   return (
     <div className="form-control w-80 sm:w-96">
       <label htmlFor={item} className="label">

--- a/frontend/src/lib/api/care.ts
+++ b/frontend/src/lib/api/care.ts
@@ -4,7 +4,7 @@ import { client } from 'src/lib/api/client'
 // 機能&リクエストURL
 
 // お世話記録 一覧(全部)
-export const getAllCares = (selectedChinchillaId) => {
+export const getAllCares = (selectedChinchillaId: number) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.get(`/all_cares?chinchilla_id=${selectedChinchillaId}`, {
     headers: {
@@ -16,7 +16,7 @@ export const getAllCares = (selectedChinchillaId) => {
 }
 
 // 体重 一覧
-export const getWeightCares = (selectedChinchillaId) => {
+export const getWeightCares = (selectedChinchillaId: number) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.get(`/weight_cares?chinchilla_id=${selectedChinchillaId}`, {
     headers: {
@@ -28,7 +28,7 @@ export const getWeightCares = (selectedChinchillaId) => {
 }
 
 // お世話記録 作成
-export const createCare = (params) => {
+export const createCare = (params: FormData) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.post('/cares', params, {
     headers: {
@@ -41,7 +41,7 @@ export const createCare = (params) => {
 }
 
 // お世話記録更新
-export const updateCare = ({ careId, params }) => {
+export const updateCare = (careId: number, params: FormData) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.put(`/cares/${careId}`, params, {
     headers: {
@@ -54,7 +54,7 @@ export const updateCare = ({ careId, params }) => {
 }
 
 // お世話記録 削除
-export const deleteCare = (careId) => {
+export const deleteCare = (careId: number) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.delete(`/cares/${careId}`, {
     headers: {

--- a/frontend/src/types/care.ts
+++ b/frontend/src/types/care.ts
@@ -1,0 +1,13 @@
+export type AllCaresType = {
+  id: number
+  careDay: string
+  careFood: string
+  careToilet: string
+  careBath: string
+  carePlay: string
+  careWeight: number | null
+  careTemperature: number | null
+  careHumidity: number | null
+  careMemo: string
+  chinchillaId: number
+}

--- a/frontend/src/validation/care.js
+++ b/frontend/src/validation/care.js
@@ -1,7 +1,0 @@
-export const validateCareMemo = (newText, setCareMemoErrorMessage) => {
-  if (newText.length > 300) {
-    setCareMemoErrorMessage('300文字以下で入力してください')
-  } else {
-    setCareMemoErrorMessage('')
-  }
-}

--- a/frontend/src/validation/care.ts
+++ b/frontend/src/validation/care.ts
@@ -1,0 +1,12 @@
+import { Dispatch, SetStateAction } from 'react'
+
+export const validateCareMemo = (
+  newText: string,
+  setCareMemoErrorMessage: Dispatch<SetStateAction<string>>
+) => {
+  if (newText.length > 300) {
+    setCareMemoErrorMessage('300文字以下で入力してください')
+  } else {
+    setCareMemoErrorMessage('')
+  }
+}


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)の一部をTypeScriptに移行しました。
残りのshadcn/ui関係は次のプルリクで移行します。

### 修正前：
- TypeScriptが導入されておらず、型安全でない。

### 修正後：
- お世話の記録ページ(`/care-record-calendar`)の一部をTypeScriptに移行しました。
- Careモデル関連のバリデーション、APIクライアントをTypeScriptに移行しました。

### 修正理由：
- フロントエンド開発を堅牢に行い、将来の機能追加や改修に備えるため。

## 実装概要
- お世話の記録ページをTypeScriptに移行 e98158e 3965152
- Careモデル関連のバリデーション、APIクライアントをTypeScriptに移行 8913d80 7051de6


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
