### PR TITLE
お世話の記録ページの型エラー等の修正

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/calendar.tsx
+++ b/frontend/src/components/pages/care-record-calendar/calendar.tsx
@@ -1,4 +1,9 @@
 import * as React from 'react'
+import { useContext } from 'react'
+
+import { useAllCares } from 'src/lib/api/care'
+import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
+
 // import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { DayPicker } from 'react-day-picker'
 import ja from 'date-fns/locale/ja'
@@ -6,24 +11,19 @@ import ja from 'date-fns/locale/ja'
 import { cn } from 'src/lib/shadcn/utils'
 import { buttonVariants } from 'src/components/pages/care-record-calendar/button'
 
-import type { AllCaresType } from 'src/types/care'
+import type { CareType } from 'src/types/care'
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>
 
-// ライブラリから提供される型に追加
-type ExtendedCalendarProps = CalendarProps & {
-  allCares: AllCaresType[]
-}
+function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  // 選択中のチンチラの状態管理（グローバル）
+  const { chinchillaId } = useContext(SelectedChinchillaIdContext)
 
-function Calendar({
-  allCares,
-  className,
-  classNames,
-  showOutsideDays = true,
-  ...props
-}: ExtendedCalendarProps) {
+  // 選択中のチンチラの全てのお世話記録
+  const { allCares } = useAllCares(chinchillaId)
+
   // 選択したチンチラのお世話記録の一覧を取得
-  const careDays = allCares.map((care: AllCaresType) => new Date(care.careDay))
+  const careDays = allCares?.map((care: CareType) => new Date(care.careDay))
 
   return (
     <DayPicker

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -87,22 +87,7 @@ export const CareRecordCalendarPage = () => {
     setHeaderDisabled(false)
 
     // すでに選択されている日付を再度クリックした場合、選択状態を解除
-    if (selectedDate && isSameDay(selectedDate, date)) {
-      // setCareId(0)
-      // setSelectedDate(null)
-      // setCareFood('')
-      // setCareToilet('')
-      // setCareBath('')
-      // setCarePlay('')
-      // setCareWeight(null)
-      // setCareTemperature(null)
-      // setCareHumidity(null)
-      // setCareMemo('')
-      return
-    }
-
-    // チンチラを選択していない場合又はお世話記録を登録していないチンチラを選択した場合
-    if (allCares.length === 0) return
+    if (selectedDate && isSameDay(selectedDate, date)) return
 
     // カレンダーで選択した日付と一致するお世話の記録をselectedCareに格納
     const selectedCare = allCares.filter(
@@ -111,6 +96,7 @@ export const CareRecordCalendarPage = () => {
     // お世話の記録がない場合
     if (selectedCare.length === 0) {
       setDisplayCare(undefined)
+      resetCareForm()
     } else {
       // お世話の記録がある場合
       setDisplayCare(selectedCare[0])

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -428,6 +428,14 @@ export const CareRecordCalendarPage = () => {
               click={() => {
                 setIsEditing(true)
                 setHeaderDisabled(true)
+                setCareFood(displayCare.careFood)
+                setCareToilet(displayCare.careToilet)
+                setCareBath(displayCare.careBath)
+                setCarePlay(displayCare.carePlay)
+                setCareWeight(displayCare.careWeight)
+                setCareTemperature(displayCare.careTemperature)
+                setCareHumidity(displayCare.careHumidity)
+                setCareMemo(displayCare.careMemo)
               }}
               disabled={!chinchillaId || !displayCare.id ? true : false}
               addStyle="btn-primary mx-3 h-14 w-32"

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -139,25 +139,6 @@ export const CareRecordCalendarPage = () => {
     }
   }
 
-  // 編集モードを解除した際に、もう一度お世話の記録を表示
-  const handleReset = () => {
-    if (selectedDate === undefined) return
-
-    const resetedCare = allCares.filter(
-      (care: CareType) =>
-        care.careDay === format(new Date(selectedDate), 'yyyy-MM-dd', { locale: ja })
-    )
-    debugLog('選択中のお世話:', resetedCare)
-    setCareFood(resetedCare[0].careFood)
-    setCareToilet(resetedCare[0].careToilet)
-    setCareBath(resetedCare[0].careBath)
-    setCarePlay(resetedCare[0].carePlay)
-    setCareWeight(resetedCare[0].careWeight)
-    setCareTemperature(resetedCare[0].careTemperature)
-    setCareHumidity(resetedCare[0].careHumidity)
-    setCareMemo(resetedCare[0].careMemo)
-  }
-
   // お世話メモのセット関数
   const handleCareMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newText = e.target.value
@@ -580,7 +561,6 @@ export const CareRecordCalendarPage = () => {
               click={() => {
                 setIsEditing(false)
                 setHeaderDisabled(false)
-                handleReset()
               }}
               addStyle="btn-secondary mx-3 h-14 w-32"
             >

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -121,7 +121,7 @@ export const CareRecordCalendarPage = () => {
       mutate(`/all_cares?chinchilla_id=${chinchillaId}`) // お世話記録を再取得
       setDisplayCare(undefined) // 選択中のお世話記録表示をリセット
       resetCareForm() // 入力フォームをリセット
-      setIsModalOpen(false) // 編集モードを解除
+      setIsModalOpen(false) // モーダルを閉じる
     } catch (err) {
       debugLog('エラー:', err)
     }
@@ -161,14 +161,9 @@ export const CareRecordCalendarPage = () => {
 
       // ステータス201 Created
       if (createCareRes.status === 201) {
-        // お世話記録を再取得
-        mutate(`/all_cares?chinchilla_id=${chinchillaId}`)
-
-        // お世話の記録を表示
-        setDisplayCare(createCareRes.data)
-
-        // 入力フォームをリセット
-        resetCareForm()
+        mutate(`/all_cares?chinchilla_id=${chinchillaId}`) // お世話記録を再取得
+        setDisplayCare(createCareRes.data) // お世話の記録を表示
+        resetCareForm() // 入力フォームをリセット
 
         debugLog('お世話記録作成:', '成功')
       } else {
@@ -203,14 +198,9 @@ export const CareRecordCalendarPage = () => {
 
       // ステータス200 ok
       if (updateCareRes.status === 200) {
-        // お世話記録を再取得
-        mutate(`/all_cares?chinchilla_id=${chinchillaId}`)
-
-        // お世話の記録を表示
-        setDisplayCare(updateCareRes.data)
-
-        // 入力フォームをリセット
-        resetCareForm()
+        mutate(`/all_cares?chinchilla_id=${chinchillaId}`) // お世話記録を再取得
+        setDisplayCare(updateCareRes.data) // お世話の記録を表示
+        resetCareForm() // 入力フォームをリセット
 
         // 編集モードを解除
         setIsEditing(false)

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -33,7 +33,6 @@ export const CareRecordCalendarPage = () => {
 
   // 選択中のチンチラの全てのお世話記録
   const { allCares } = useAllCares(chinchillaId)
-  console.log('allCares:', allCares)
 
   // 編集モードの状態管理
   const [isEditing, setIsEditing] = useState(false)
@@ -53,7 +52,6 @@ export const CareRecordCalendarPage = () => {
 
   // 表示用の状態管理(中身が空か1つの配列)
   const [displayCare, setDisplayCare] = useState<CareType | undefined>(undefined)
-  console.log('displayCare:', displayCare)
 
   // お世話メモのバリデーションメッセージ
   const [careMemoErrorMessage, setCareMemoErrorMessage] = useState('')

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -80,6 +80,11 @@ export const CareRecordCalendarPage = () => {
       )
     }
 
+    // カレンダーで選択した日付と一致するお世話の記録をselectedCareに格納
+    const selectedCare = allCares.filter(
+      (care: CareType) => care.careDay === format(new Date(date), 'yyyy-MM-dd', { locale: ja })
+    )
+
     // 日付を選択した場合は編集モードを解除
     setIsEditing(false)
     setHeaderDisabled(false)
@@ -87,17 +92,16 @@ export const CareRecordCalendarPage = () => {
     // すでに選択されている日付を再度クリックした場合、選択状態を解除
     if (selectedDate && isSameDay(selectedDate, date)) return
 
-    // カレンダーで選択した日付と一致するお世話の記録をselectedCareに格納
-    const selectedCare = allCares.filter(
-      (care: CareType) => care.careDay === format(new Date(date), 'yyyy-MM-dd', { locale: ja })
-    )
+    // お世話の記録がある場合
+    if (selectedCare.length === 1) {
+      setDisplayCare(selectedCare[0])
+      resetCareForm()
+    }
+
     // お世話の記録がない場合
     if (selectedCare.length === 0) {
       setDisplayCare(undefined)
       resetCareForm()
-    } else {
-      // お世話の記録がある場合
-      setDisplayCare(selectedCare[0])
     }
 
     debugLog('選択中のお世話:', selectedCare)

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react'
+import { useState, useContext, useEffect } from 'react'
 import { AxiosResponse } from 'axios'
 import { mutate } from 'swr'
 
@@ -224,6 +224,16 @@ export const CareRecordCalendarPage = () => {
       debugLog('エラー:', err)
     }
   }
+
+  // 選択中のチンチラが変わるタイミングで状態管理をリセット
+  useEffect(() => {
+    setIsEditing(false)
+    setIsModalOpen(false)
+    resetCareForm()
+    setDisplayCare(undefined)
+    setCareMemoErrorMessage('')
+    setSelectedDate(undefined)
+  }, [chinchillaId])
 
   return (
     <div className="mx-3 my-24 grid place-content-center place-items-center gap-y-4 sm:my-28 sm:gap-y-6">

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -256,7 +256,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 日付未選択 */}
-      {!selectedDate && (
+      {chinchillaId !== 0 && !selectedDate && (
         <p className="text-sm text-dark-black sm:text-base">
           <FontAwesomeIcon icon={faHandPointer} className="mr-1 text-dark-blue" />
           カレンダーから日付を選択してください
@@ -264,7 +264,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 登録モード */}
-      {chinchillaId && selectedDate && displayCare === undefined && isEditing === false && (
+      {chinchillaId !== 0 && selectedDate && displayCare === undefined && isEditing === false && (
         <>
           {/* 登録モード：お世話の記録 */}
           <div className="h-[215px] w-80 rounded-xl border border-solid border-dark-blue bg-ligth-white sm:h-[300px] sm:w-[500px]">
@@ -372,7 +372,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 表示モード */}
-      {chinchillaId && selectedDate && displayCare !== undefined && isEditing === false && (
+      {chinchillaId !== 0 && selectedDate && displayCare !== undefined && isEditing === false && (
         <>
           {/* 表示モード：お世話の記録 */}
           <div className="h-[300px] w-80 rounded-xl bg-ligth-white sm:h-[400px]  sm:w-[500px]">
@@ -456,7 +456,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 編集モード */}
-      {chinchillaId && selectedDate && displayCare !== undefined && isEditing === true && (
+      {chinchillaId !== 0 && selectedDate && displayCare !== undefined && isEditing === true && (
         <>
           {/* 編集モード：お世話の記録 */}
           <div className="h-[215px] w-80 rounded-xl border border-solid border-dark-blue bg-ligth-white sm:h-[300px] sm:w-[500px]">

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -16,7 +16,7 @@ import { Button } from 'src/components/shared/Button'
 import { Calendar } from 'src/components/pages/care-record-calendar/calendar'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faHandPointer } from '@fortawesome/free-solid-svg-icons'
+import { faHandPointer, faCalendarXmark } from '@fortawesome/free-solid-svg-icons'
 
 import { validateCareMemo } from 'src/validation/care'
 
@@ -227,21 +227,32 @@ export const CareRecordCalendarPage = () => {
     <div className="mx-3 my-24 grid place-content-center place-items-center gap-y-4 sm:my-28 sm:gap-y-6">
       <PageTitle pageTitle="お世話の記録" />
 
-      {/* カレンダー */}
-      <Calendar
-        // 1日のみ選択可能
-        mode="single"
-        selected={selectedDate}
-        onSelect={setSelectedDate}
-        onDayClick={handleSelectedCare}
-      />
-
       {/* チンチラ未選択 */}
       {chinchillaId === 0 && (
-        <p className="text-sm text-dark-black sm:text-base">
-          <FontAwesomeIcon icon={faHandPointer} className="mr-1 text-dark-blue" />
-          チンチラを選択してください
-        </p>
+        <div className="mt-8 w-80 rounded-xl bg-ligth-white p-8 sm:w-[500px] sm:p-10">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-[50%] bg-light-blue sm:h-32 sm:w-32">
+            <FontAwesomeIcon
+              icon={faCalendarXmark}
+              className="text-2xl font-bold text-ligth-white sm:text-5xl"
+            />
+          </div>
+          <p className="mt-5 text-center text-sm text-dark-black sm:mt-10 sm:text-base">
+            チンチラが選択されていません。 <br /> <br />
+            お世話を記録したいチンチラを <br />
+            ヘッダーから選択してください。 <br />
+          </p>
+        </div>
+      )}
+
+      {/* カレンダー */}
+      {chinchillaId !== 0 && (
+        <Calendar
+          // 1日のみ選択可能
+          mode="single"
+          selected={selectedDate}
+          onSelect={setSelectedDate}
+          onDayClick={handleSelectedCare}
+        />
       )}
 
       {/* 日付未選択 */}

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useContext } from 'react'
+import { useState, useContext } from 'react'
 import { AxiosResponse } from 'axios'
+import { mutate } from 'swr'
 
-import { getAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
+import { useAllCares, createCare, deleteCare, updateCare } from 'src/lib/api/care'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
 
 import { InputRadioButtonItem } from 'src/components/pages/care-record-calendar/inputRadioButtonItem'
@@ -24,14 +25,15 @@ import ja from 'date-fns/locale/ja'
 
 import { debugLog } from 'src/lib/debug/debugLog'
 
-import type { AllCaresType } from 'src/types/care'
+import type { CareType } from 'src/types/care'
 
 export const CareRecordCalendarPage = () => {
-  const [allCares, setAllCares] = useState<AllCaresType[]>([])
-  const [careId, setCareId] = useState(0)
-
   // 選択中のチンチラの状態管理（グローバル）
   const { chinchillaId, setHeaderDisabled } = useContext(SelectedChinchillaIdContext)
+
+  // 選択中のチンチラの全てのお世話記録
+  const { allCares } = useAllCares(chinchillaId)
+  console.log('allCares:', allCares)
 
   // 編集モードの状態管理
   const [isEditing, setIsEditing] = useState(false)
@@ -49,42 +51,27 @@ export const CareRecordCalendarPage = () => {
   const [careHumidity, setCareHumidity] = useState<number | null>(null)
   const [careMemo, setCareMemo] = useState('')
 
+  // 表示用の状態管理(中身が空か1つの配列)
+  const [displayCare, setDisplayCare] = useState<CareType | undefined>(undefined)
+  console.log('displayCare:', displayCare)
+
   // お世話メモのバリデーションメッセージ
   const [careMemoErrorMessage, setCareMemoErrorMessage] = useState('')
 
   // 選択中のカレンダーの日付の状態管理
-  const [selectedDate, setSelectedDate] = useState(null)
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined)
 
-  // チンチラを選択中の場合に、お世話の記録を取得
-  const fetch = async () => {
-    try {
-      if (chinchillaId) {
-        const response = await getAllCares(chinchillaId)
-        const res = response as AxiosResponse
-        debugLog('お世話記録一覧:', res.data)
-        setAllCares(res.data)
-
-        // 別のチンチラを選択する際に、画面の表示をリセット
-        setCareId(0)
-        setSelectedDate(null)
-        setCareFood('')
-        setCareToilet('')
-        setCareBath('')
-        setCarePlay('')
-        setCareWeight(null)
-        setCareTemperature(null)
-        setCareHumidity(null)
-        setCareMemo('')
-      }
-    } catch (err) {
-      debugLog('エラー:', err)
-    }
+  // 入力フォームのリセット用関数
+  const resetCareForm = () => {
+    setCareFood('')
+    setCareToilet('')
+    setCareBath('')
+    setCarePlay('')
+    setCareWeight(null)
+    setCareTemperature(null)
+    setCareHumidity(null)
+    setCareMemo('')
   }
-
-  // chinchillaIdの変更を検知してレンダリング
-  useEffect(() => {
-    fetch()
-  }, [chinchillaId])
 
   // 選択した日付のお世話の記録を表示
   const handleSelectedCare = (date: Date) => {
@@ -101,16 +88,16 @@ export const CareRecordCalendarPage = () => {
 
     // すでに選択されている日付を再度クリックした場合、選択状態を解除
     if (selectedDate && isSameDay(selectedDate, date)) {
-      setCareId(0)
-      setSelectedDate(null)
-      setCareFood('')
-      setCareToilet('')
-      setCareBath('')
-      setCarePlay('')
-      setCareWeight(null)
-      setCareTemperature(null)
-      setCareHumidity(null)
-      setCareMemo('')
+      // setCareId(0)
+      // setSelectedDate(null)
+      // setCareFood('')
+      // setCareToilet('')
+      // setCareBath('')
+      // setCarePlay('')
+      // setCareWeight(null)
+      // setCareTemperature(null)
+      // setCareHumidity(null)
+      // setCareMemo('')
       return
     }
 
@@ -119,65 +106,34 @@ export const CareRecordCalendarPage = () => {
 
     // カレンダーで選択した日付と一致するお世話の記録をselectedCareに格納
     const selectedCare = allCares.filter(
-      (care) => care.careDay === format(new Date(date), 'yyyy-MM-dd', { locale: ja })
+      (care: CareType) => care.careDay === format(new Date(date), 'yyyy-MM-dd', { locale: ja })
     )
-
-    debugLog('選択中のお世話:', selectedCare)
-
     // お世話の記録がない場合
     if (selectedCare.length === 0) {
-      setCareId(0)
-      setCareFood('')
-      setCareToilet('')
-      setCareBath('')
-      setCarePlay('')
-      setCareWeight(null)
-      setCareTemperature(null)
-      setCareHumidity(null)
-      setCareMemo('')
+      setDisplayCare(undefined)
     } else {
       // お世話の記録がある場合
-      setCareId(selectedCare[0].id)
-      setCareFood(selectedCare[0].careFood)
-      setCareToilet(selectedCare[0].careToilet)
-      setCareBath(selectedCare[0].careBath)
-      setCarePlay(selectedCare[0].carePlay)
-      setCareWeight(selectedCare[0].careWeight)
-      setCareTemperature(selectedCare[0].careTemperature)
-      setCareHumidity(selectedCare[0].careHumidity)
-      setCareMemo(selectedCare[0].careMemo)
+      setDisplayCare(selectedCare[0])
     }
+
+    debugLog('選択中のお世話:', selectedCare)
   }
 
   // お世話の記録を削除
   const handleDelete = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (!careId) {
-      alert('お世話を選択してください')
-      return
-    }
+    if (!chinchillaId || !displayCare) return
     e.preventDefault()
+
+    const careId = displayCare.id
+
     try {
-      const deleteCareRes = await deleteCare(careId)
-      const getAllCaresRes = await getAllCares(chinchillaId)
-
-      if (!deleteCareRes || !getAllCaresRes) return
-
+      const deleteCareRes = (await deleteCare(careId)) as AxiosResponse
       debugLog('削除レス:', deleteCareRes)
-      debugLog('お世話一覧:', getAllCaresRes.data)
 
-      // 削除後、画面の表示をリセット
-      setAllCares(getAllCaresRes.data)
-      setCareId(0)
-      setCareFood('')
-      setCareToilet('')
-      setCareBath('')
-      setCarePlay('')
-      setCareWeight(null)
-      setCareTemperature(null)
-      setCareHumidity(null)
-      setCareMemo('')
-
-      setIsModalOpen(false)
+      mutate(`/all_cares?chinchilla_id=${chinchillaId}`) // お世話記録を再取得
+      setDisplayCare(undefined) // 選択中のお世話記録表示をリセット
+      resetCareForm() // 入力フォームをリセット
+      setIsModalOpen(false) // 編集モードを解除
     } catch (err) {
       debugLog('エラー:', err)
     }
@@ -185,8 +141,11 @@ export const CareRecordCalendarPage = () => {
 
   // 編集モードを解除した際に、もう一度お世話の記録を表示
   const handleReset = () => {
+    if (selectedDate === undefined) return
+
     const resetedCare = allCares.filter(
-      (care) => care.careDay === format(new Date(selectedDate), 'yyyy-MM-dd', { locale: ja })
+      (care: CareType) =>
+        care.careDay === format(new Date(selectedDate), 'yyyy-MM-dd', { locale: ja })
     )
     debugLog('選択中のお世話:', resetedCare)
     setCareFood(resetedCare[0].careFood)
@@ -197,22 +156,6 @@ export const CareRecordCalendarPage = () => {
     setCareTemperature(resetedCare[0].careTemperature)
     setCareHumidity(resetedCare[0].careHumidity)
     setCareMemo(resetedCare[0].careMemo)
-  }
-
-  // create;FormData形式でデータを作成
-  const createFormData = () => {
-    const formData = new FormData()
-    formData.append('care[careDay]', selectedDate)
-    formData.append('care[careFood]', careFood)
-    formData.append('care[careToilet]', careToilet)
-    formData.append('care[careBath]', careBath)
-    formData.append('care[carePlay]', carePlay)
-    formData.append('care[careWeight]', careWeight === null ? '' : careWeight)
-    formData.append('care[careTemperature]', careTemperature === null ? '' : careTemperature)
-    formData.append('care[careHumidity]', careHumidity === null ? '' : careHumidity)
-    formData.append('care[careMemo]', careMemo)
-    formData.append('care[chinchillaId]', chinchillaId)
-    return formData
   }
 
   // お世話メモのセット関数
@@ -227,34 +170,36 @@ export const CareRecordCalendarPage = () => {
 
   // create;お世話の記録を登録
   const handleCreate = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!chinchillaId || !selectedDate || displayCare !== undefined || isEditing === true) return
     e.preventDefault()
-    const params = createFormData()
+
+    const params = {
+      careDay: format(new Date(selectedDate), 'yyyy-MM-dd', { locale: ja }),
+      careFood: careFood,
+      careToilet: careToilet,
+      careBath: careBath,
+      carePlay: carePlay,
+      careWeight: careWeight,
+      careTemperature: careTemperature,
+      careHumidity: careHumidity,
+      careMemo: careMemo,
+      chinchillaId: chinchillaId
+    }
+
     try {
       const createCareRes = (await createCare(params)) as AxiosResponse
-      const getAllCaresRes = (await getAllCares(chinchillaId)) as AxiosResponse
-
       debugLog('作成レス:', createCareRes)
-      debugLog('お世話一覧:', getAllCaresRes.data)
 
       // ステータス201 Created
       if (createCareRes.status === 201) {
-        setAllCares(getAllCaresRes.data)
+        // お世話記録を再取得
+        mutate(`/all_cares?chinchilla_id=${chinchillaId}`)
 
-        // 作成後にお世話の記録を表示
-        const resetedCare = getAllCaresRes.data.filter(
-          (care: AllCaresType) =>
-            care.careDay === format(new Date(selectedDate), 'yyyy-MM-dd', { locale: ja })
-        )
-        debugLog('選択中のお世話:', resetedCare)
-        setCareId(resetedCare[0].id)
-        setCareFood(resetedCare[0].careFood)
-        setCareToilet(resetedCare[0].careToilet)
-        setCareBath(resetedCare[0].careBath)
-        setCarePlay(resetedCare[0].carePlay)
-        setCareWeight(resetedCare[0].careWeight)
-        setCareTemperature(resetedCare[0].careTemperature)
-        setCareHumidity(resetedCare[0].careHumidity)
-        setCareMemo(resetedCare[0].careMemo)
+        // お世話の記録を表示
+        setDisplayCare(createCareRes.data)
+
+        // 入力フォームをリセット
+        resetCareForm()
 
         debugLog('お世話記録作成:', '成功')
       } else {
@@ -265,38 +210,43 @@ export const CareRecordCalendarPage = () => {
     }
   }
 
-  // update:FormData形式でデータを作成
-  const updateFormData = () => {
-    const formData = new FormData()
-    formData.append('care[careFood]', careFood)
-    formData.append('care[careToilet]', careToilet)
-    formData.append('care[careBath]', careBath)
-    formData.append('care[carePlay]', carePlay)
-    formData.append('care[careWeight]', careWeight === null ? '' : careWeight)
-    formData.append('care[careTemperature]', careTemperature === null ? '' : careTemperature)
-    formData.append('care[careHumidity]', careHumidity === null ? '' : careHumidity)
-    formData.append('care[careMemo]', careMemo)
-    return formData
-  }
-
   // update:お世話の記録を更新
   const handleUpdate = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!chinchillaId || !selectedDate || displayCare === undefined || isEditing === false) return
     e.preventDefault()
-    const params = updateFormData()
+
+    const careId = displayCare.id
+
+    const params = {
+      careFood: careFood,
+      careToilet: careToilet,
+      careBath: careBath,
+      carePlay: carePlay,
+      careWeight: careWeight,
+      careTemperature: careTemperature,
+      careHumidity: careHumidity,
+      careMemo: careMemo
+    }
+
     try {
-      const updateCareRes = (await updateCare({
-        careId,
-        params
-      })) as AxiosResponse
-      const getAllCaresRes = (await getAllCares(chinchillaId)) as AxiosResponse
+      const updateCareRes = (await updateCare(careId, params)) as AxiosResponse
       debugLog('更新レス:', updateCareRes)
-      debugLog('お世話一覧:', getAllCaresRes.data)
 
       // ステータス200 ok
       if (updateCareRes.status === 200) {
-        setAllCares(getAllCaresRes.data)
+        // お世話記録を再取得
+        mutate(`/all_cares?chinchilla_id=${chinchillaId}`)
+
+        // お世話の記録を表示
+        setDisplayCare(updateCareRes.data)
+
+        // 入力フォームをリセット
+        resetCareForm()
+
+        // 編集モードを解除
         setIsEditing(false)
         setHeaderDisabled(false)
+
         debugLog('お世話記録更新:', '成功')
       } else {
         alert('お世話記録更新失敗')
@@ -309,6 +259,7 @@ export const CareRecordCalendarPage = () => {
   return (
     <div className="mx-3 my-24 grid place-content-center place-items-center gap-y-4 sm:my-28 sm:gap-y-6">
       <PageTitle pageTitle="お世話の記録" />
+
       {/* カレンダー */}
       <Calendar
         // 1日のみ選択可能
@@ -316,7 +267,6 @@ export const CareRecordCalendarPage = () => {
         selected={selectedDate}
         onSelect={setSelectedDate}
         onDayClick={handleSelectedCare}
-        allCares={allCares}
       />
 
       {/* チンチラ未選択 */}
@@ -336,7 +286,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 登録モード */}
-      {careId === 0 && selectedDate && chinchillaId && (
+      {chinchillaId && selectedDate && displayCare === undefined && isEditing === false && (
         <>
           {/* 登録モード：お世話の記録 */}
           <div className="h-[215px] w-80 rounded-xl border border-solid border-dark-blue bg-ligth-white sm:h-[300px] sm:w-[500px]">
@@ -444,21 +394,27 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 表示モード */}
-      {careId !== 0 && selectedDate && chinchillaId && isEditing === false && (
+      {chinchillaId && selectedDate && displayCare !== undefined && isEditing === false && (
         <>
           {/* 表示モード：お世話の記録 */}
           <div className="h-[300px] w-80 rounded-xl bg-ligth-white sm:h-[400px]  sm:w-[500px]">
-            <DisplayRadioButtonItem label="食事" item="careFood" value={careFood} />
-            <DisplayRadioButtonItem label="トイレ" item="careToilet" value={careToilet} />
-            <DisplayRadioButtonItem label="砂浴び" item="careBath" value={careBath} />
-            <DisplayRadioButtonItem label="部屋んぽ" item="carePlay" value={carePlay} />
+            <DisplayRadioButtonItem label="食事" item="careFood" value={displayCare.careFood} />
+            <DisplayRadioButtonItem
+              label="トイレ"
+              item="careToilet"
+              value={displayCare.careToilet}
+            />
+            <DisplayRadioButtonItem label="砂浴び" item="careBath" value={displayCare.careBath} />
+            <DisplayRadioButtonItem label="部屋んぽ" item="carePlay" value={displayCare.carePlay} />
 
             {/* 表示モード：体重 */}
             <div className="mx-5 mt-3 flex items-center border-b border-solid border-b-light-black pb-2 sm:mx-10 sm:mt-5">
               <p className="w-28 text-center text-sm text-dark-black sm:text-base">体重</p>
               <div className="flex grow justify-evenly text-center">
-                {careWeight && (
-                  <p className="text-center text-sm text-dark-black sm:text-base">{careWeight}g</p>
+                {displayCare.careWeight && (
+                  <p className="text-center text-sm text-dark-black sm:text-base">
+                    {displayCare.careWeight}g
+                  </p>
                 )}
               </div>
             </div>
@@ -467,14 +423,14 @@ export const CareRecordCalendarPage = () => {
             <div className="mx-5 mt-3 flex items-center border-b border-solid border-b-light-black pb-2 sm:mx-10 sm:mt-5">
               <p className="w-28 text-center text-sm text-dark-black sm:text-base">気温・湿度</p>
               <div className="flex grow justify-evenly text-center">
-                {careTemperature && (
+                {displayCare.careTemperature && (
                   <p className="text-center text-sm text-dark-black sm:text-base">
-                    {careTemperature}℃
+                    {displayCare.careTemperature}℃
                   </p>
                 )}
-                {careHumidity && (
+                {displayCare.careHumidity && (
                   <p className="text-center text-sm text-dark-black sm:text-base">
-                    {careHumidity}%
+                    {displayCare.careHumidity}%
                   </p>
                 )}
               </div>
@@ -482,7 +438,7 @@ export const CareRecordCalendarPage = () => {
           </div>
 
           {/* 表示モード：お世話のメモ */}
-          <DisplayMemo contents={careMemo} />
+          <DisplayMemo contents={displayCare.careMemo} />
 
           {/* 表示モード：編集・削除ボタン */}
           <div>
@@ -492,7 +448,7 @@ export const CareRecordCalendarPage = () => {
                 setIsEditing(true)
                 setHeaderDisabled(true)
               }}
-              disabled={!chinchillaId || !careId ? true : false}
+              disabled={!chinchillaId || !displayCare.id ? true : false}
               addStyle="btn-primary mx-3 h-14 w-32"
             >
               編集
@@ -514,7 +470,7 @@ export const CareRecordCalendarPage = () => {
       )}
 
       {/* 編集モード */}
-      {careId !== 0 && selectedDate && chinchillaId && isEditing === true && (
+      {chinchillaId && selectedDate && displayCare !== undefined && isEditing === true && (
         <>
           {/* 編集モード：お世話の記録 */}
           <div className="h-[215px] w-80 rounded-xl border border-solid border-dark-blue bg-ligth-white sm:h-[300px] sm:w-[500px]">

--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -96,12 +96,14 @@ export const CareRecordCalendarPage = () => {
     if (selectedCare.length === 1) {
       setDisplayCare(selectedCare[0])
       resetCareForm()
+      setCareMemoErrorMessage('')
     }
 
     // お世話の記録がない場合
     if (selectedCare.length === 0) {
       setDisplayCare(undefined)
       resetCareForm()
+      setCareMemoErrorMessage('')
     }
 
     debugLog('選択中のお世話:', selectedCare)
@@ -568,6 +570,8 @@ export const CareRecordCalendarPage = () => {
               click={() => {
                 setIsEditing(false)
                 setHeaderDisabled(false)
+                resetCareForm()
+                setCareMemoErrorMessage('')
               }}
               addStyle="btn-secondary mx-3 h-14 w-32"
             >

--- a/frontend/src/lib/api/care.ts
+++ b/frontend/src/lib/api/care.ts
@@ -1,18 +1,41 @@
 import Cookies from 'js-cookie'
+import useSWR from 'swr'
 import { client } from 'src/lib/api/client'
+
+import type { CreateCareType, UpdateCareType } from 'src/types/care'
 
 // 機能&リクエストURL
 
+const fetchWithToken = (url: string) => {
+  const accessToken = Cookies.get('_access_token')
+  const clientToken = Cookies.get('_client')
+  const uid = Cookies.get('_uid')
+
+  if (!accessToken || !client || !uid) return
+
+  return client
+    .get(url, {
+      headers: {
+        'access-token': accessToken,
+        client: clientToken,
+        uid: uid
+      }
+    })
+    .then((res) => res.data)
+}
+
 // お世話記録 一覧(全部)
-export const getAllCares = (selectedChinchillaId: number) => {
-  if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
-  return client.get(`/all_cares?chinchilla_id=${selectedChinchillaId}`, {
-    headers: {
-      'access-token': Cookies.get('_access_token'),
-      client: Cookies.get('_client'),
-      uid: Cookies.get('_uid')
-    }
-  })
+export const useAllCares = (chinchillaId: number) => {
+  const { data, error, isLoading } = useSWR(
+    chinchillaId !== 0 ? `/all_cares?chinchilla_id=${chinchillaId}` : null,
+    fetchWithToken
+  )
+
+  return {
+    allCares: data,
+    isLoading,
+    isError: error
+  }
 }
 
 // 体重 一覧
@@ -28,27 +51,25 @@ export const getWeightCares = (selectedChinchillaId: number) => {
 }
 
 // お世話記録 作成
-export const createCare = (params: FormData) => {
+export const createCare = (params: CreateCareType) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.post('/cares', params, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),
-      uid: Cookies.get('_uid'),
-      'content-type': 'multipart/form-data'
+      uid: Cookies.get('_uid')
     }
   })
 }
 
 // お世話記録更新
-export const updateCare = (careId: number, params: FormData) => {
+export const updateCare = (careId: number, params: UpdateCareType) => {
   if (!Cookies.get('_access_token') || !Cookies.get('_client') || !Cookies.get('_uid')) return
   return client.put(`/cares/${careId}`, params, {
     headers: {
       'access-token': Cookies.get('_access_token'),
       client: Cookies.get('_client'),
-      uid: Cookies.get('_uid'),
-      'content-type': 'multipart/form-data'
+      uid: Cookies.get('_uid')
     }
   })
 }

--- a/frontend/src/types/care.ts
+++ b/frontend/src/types/care.ts
@@ -11,3 +11,27 @@ export type AllCaresType = {
   careMemo: string
   chinchillaId: number
 }
+
+export type CreateCareType = {
+  careDay: string
+  careFood: string
+  careToilet: string
+  careBath: string
+  carePlay: string
+  careWeight: number | null
+  careTemperature: number | null
+  careHumidity: number | null
+  careMemo: string
+  chinchillaId: number
+}
+
+export type UpdateCareType = {
+  careFood: string
+  careToilet: string
+  careBath: string
+  carePlay: string
+  careWeight: number | null
+  careTemperature: number | null
+  careHumidity: number | null
+  careMemo: string
+}

--- a/frontend/src/types/care.ts
+++ b/frontend/src/types/care.ts
@@ -1,4 +1,4 @@
-export type AllCaresType = {
+export type CareType = {
   id: number
   careDay: string
   careFood: string


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)において、型エラー等の修正を行いました。


### 修正前：
- お世話記録のPOST/PUTリクエストのパラメータやカレンダーの日付等について、型エラーが起きている。
- お世話記録のレコードについて、CRUD機能の全ての同じstate/useStateで管理しており、状態管理のバグが起きやすく改修しにくい。

### 修正後：
- お世話の記録ページ(`/care-record-calendar`)関連で起きている型エラーを修正しました。
- お世話記録のGETリクエストはSWRで行い、取得したデータと入力フォームの値を個別に状態管理するように修正しました。

### 修正理由：
- コンパイルエラーの修正のため。
- コードの保守性・可読性の向上のため。
- キャッシュを利用し、パフォーマンスを向上させるため。

## 実装概要
- 型定義に関する追加・修正 fb74468 56776ce
- コンパイルエラー、APIクライアント、SWRでのデータ取得に関する修正 2e99069 f92fb76 8490404
- お世話の記録ページの状態管理に関するバグ修正 07bc8b1 7c7ac58 d470014 d56d818 c0e0d5a 4ceedd7
- その他の修正 2140cff 7c5cd80 9dd5b84 7477e59


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
