### PR TITLE
お世話の記録ページでチンチラのデータを取得する前に初期表示される問題の修正

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -29,7 +29,7 @@ import type { CareType } from 'src/types/care'
 
 export const CareRecordCalendarPage = () => {
   // 選択中のチンチラの状態管理（グローバル）
-  const { chinchillaId, setHeaderDisabled } = useContext(SelectedChinchillaIdContext)
+  const { chinchillaId, headerName, setHeaderDisabled } = useContext(SelectedChinchillaIdContext)
 
   // 選択中のチンチラの全てのお世話記録
   const { allCares } = useAllCares(chinchillaId)
@@ -232,7 +232,8 @@ export const CareRecordCalendarPage = () => {
       <PageTitle pageTitle="お世話の記録" />
 
       {/* チンチラ未選択 */}
-      {chinchillaId === 0 && (
+      {/* ヘッダーのチンチラセットに合わせて表示 */}
+      {headerName === '' && (
         <div className="mt-8 w-80 rounded-xl bg-ligth-white p-8 sm:w-[500px] sm:p-10">
           <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-[50%] bg-light-blue sm:h-32 sm:w-32">
             <FontAwesomeIcon

--- a/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.tsx
+++ b/frontend/src/components/pages/mychinchilla/chinchilla-profile/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useEffect, useRef, useCallback, useState, useContext } from 'react'
 import { useRouter } from 'next/router'
+import { mutate } from 'swr'
 
 import { useChinchillaProfile, updateChinchilla, deleteChinchilla } from 'src/lib/api/chinchilla'
 import { SelectedChinchillaIdContext } from 'src/contexts/chinchilla'
@@ -27,7 +28,6 @@ import { utcToZonedTime } from 'date-fns-tz'
 import { debugLog } from 'src/lib/debug/debugLog'
 
 import type { RhfUpdateChinchillaType } from 'src/types/chinchilla'
-import { mutate } from 'swr'
 
 export const ChinchillaProfilePage = () => {
   const router = useRouter()


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)において、チンチラのデータを取得する前に、チンチラを選択していない時の画面が一瞬表示、その後チンチラがセットされるとカレンダーが表示されるという画面表示のちらつきを修正しました。


### 修正前：
- お世話の記録ページ(`/care-record-calendar`)において、チンチラのデータを取得する前に、チンチラを選択していない時の画面が一瞬表示、その後チンチラがセットされるとカレンダーが表示されるため、UXが悪い。

### 修正後：
- チンチラのデータが取得できたあとに、チンチラを選択していない場合の表示(チンチラ選択の案内)またはカレンダーの表示を出し分けるよう修正しました。

### 修正理由：
- UI/UXの向上のため。

## 実装概要
- チンチラのデータが取得できたあとに、表示を出し分けるよう修正 0919559
- その他の修正 0c87853


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
