### PR TITLE
TypeScriptに移行 #8

### DIFF
--- a/frontend/src/components/pages/weight-chart/weightChart.tsx
+++ b/frontend/src/components/pages/weight-chart/weightChart.tsx
@@ -1,9 +1,15 @@
 import { useState, useEffect } from 'react'
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, TooltipProps } from 'recharts'
 
-export const WeightChart = ({ filteredData }) => {
+import type { ChangeCareDayToNumCareWeightType } from 'src/types/care'
+
+type Props = { filteredData: ChangeCareDayToNumCareWeightType[] }
+
+export const WeightChart = (props: Props) => {
+  const { filteredData } = props
+
   // ツールチップの表示形式をカスタマイズ
-  const CustomTooltip = ({ active, payload, label }) => {
+  const CustomTooltip: React.FC<TooltipProps<number, string>> = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
       const date = new Date(label)
       return (

--- a/frontend/src/types/care.ts
+++ b/frontend/src/types/care.ts
@@ -35,3 +35,7 @@ export type UpdateCareType = {
   careHumidity: number | null
   careMemo: string
 }
+
+export type GetCareWeightType = { careDay: string; careWeight: number }
+export type ChangeCareDayToDateCareWeightType = { careDay: Date; careWeight: number }
+export type ChangeCareDayToNumCareWeightType = { careDay: number; careWeight: number }


### PR DESCRIPTION
# 説明
以下のとおり体重ページ(/weight-chart)をTypeScriptに移行しました。


### 修正前：
- TypeScriptが導入されておらず、型安全でない。

### 修正後：
- 体重ページ(/weight-chart)をTypeScriptに移行しました。

### 修正理由：
- フロントエンド開発を堅牢に行い、将来の機能追加や改修に備えるため。

## 実装概要
- 体重ページをTypeScriptに移行 26f2af1


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
