### PR TITLE
お世話の記録ページでチンチラを選択していない場合の表示にチンチラ登録ページのリンクを追加

### DIFF
--- a/frontend/src/components/pages/care-record-calendar/index.tsx
+++ b/frontend/src/components/pages/care-record-calendar/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useContext, useEffect } from 'react'
+import Link from 'next/link'
 import { AxiosResponse } from 'axios'
 import { mutate } from 'swr'
 
@@ -234,19 +235,30 @@ export const CareRecordCalendarPage = () => {
       {/* チンチラ未選択 */}
       {/* ヘッダーのチンチラセットに合わせて表示 */}
       {headerName === '' && (
-        <div className="mt-8 w-80 rounded-xl bg-ligth-white p-8 sm:w-[500px] sm:p-10">
-          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-[50%] bg-light-blue sm:h-32 sm:w-32">
-            <FontAwesomeIcon
-              icon={faCalendarXmark}
-              className="text-2xl font-bold text-ligth-white sm:text-5xl"
-            />
+        <>
+          <div className="mt-2 w-80 rounded-xl bg-ligth-white p-8 sm:w-[500px] sm:p-10">
+            <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-[50%] bg-light-blue sm:h-32 sm:w-32">
+              <FontAwesomeIcon
+                icon={faCalendarXmark}
+                className="text-2xl font-bold text-ligth-white sm:text-5xl"
+              />
+            </div>
+            <p className="mt-5 text-center text-sm text-dark-black sm:mt-10 sm:text-base">
+              チンチラが選択されていません。
+              <br />
+              <br />
+              お世話を記録したいチンチラを登録し、
+              <br />
+              ヘッダーから選択してください。
+            </p>
           </div>
-          <p className="mt-5 text-center text-sm text-dark-black sm:mt-10 sm:text-base">
-            チンチラが選択されていません。 <br /> <br />
-            お世話を記録したいチンチラを <br />
-            ヘッダーから選択してください。 <br />
-          </p>
-        </div>
+          <Link
+            href="/chinchilla-registration"
+            className="link mt-10 text-sm text-dark-black duration-100 hover:text-dark-black/50 sm:text-base"
+          >
+            チンチラの登録はこちら
+          </Link>
+        </>
       )}
 
       {/* カレンダー */}

--- a/frontend/src/components/shared/Header/index.tsx
+++ b/frontend/src/components/shared/Header/index.tsx
@@ -74,6 +74,10 @@ export const Header = () => {
           setHeaderName(res.data[0].chinchillaName)
           setHeaderImage(res.data[0].chinchillaImage)
         }
+
+        if (res.data.length === 0) {
+          setHeaderName('')
+        }
       } catch (err) {
         debugLog('エラー:', err)
       }

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -45,10 +45,10 @@ export const AuthProvider = ({ children }: Props) => {
     }
   }
 
-  //ログイン状態を監視
+  // 初回レンダリング時にログイン状態をチェック
   useEffect(() => {
     handleGetCurrentUser()
-  }, [setCurrentUser])
+  }, [])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }


### PR DESCRIPTION
# 説明
以下のとおりお世話の記録ページ(`/care-record-calendar`)でチンチラを選択していない場合の表示に、チンチラ登録ページのリンクを追加等しました。


### 修正前：
- ログイン後、チンチラが登録されていない場合に、お世話の記録ページ(`/care-record-calendar`)でチンチラが登録されていない場合の画面が表示されない。
- お世話の記録ページ(`/care-record-calendar`)

### 修正後：
- ログイン後にチンチラが登録されていない場合に、headerNameに空文字をセットし、表示されるよう修正しました。
- チンチラを選択していない場合の表示に、お世話の記録ページ(`/care-record-calendar`)からチンチラ登録ページへのリンクを追加しました。

### 修正理由：
- UI/UXの向上のため。

## 実装概要
- ログイン後にチンチラが登録されていない場合にheaderNameに空文字をセットするよう修正 3fcd30f
- お世話の記録ページからチンチラ登録ページへのリンクを追加 a6b01f0
- その他の修正 94b6523 


# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
| ![スクリーンショット 2024-01-18 20 42 13](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/ea0cb318-c1a8-40bd-b693-bd3b9e34937d) | ![スクリーンショット 2024-01-18 20 41 22](https://github.com/ponchoay/chinchilla-web-app/assets/129176088/92d52de5-74f5-41ad-9f59-ed6bc816d0f5)  |



# 変更のタイプ
- [x] 新機能
- [ ] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
