### PR TITLE
不要なグローバルstateの削除及びヘッダー・フッターの出し分けロジックの修正

### DIFF
--- a/frontend/src/components/pages/mypage/index.tsx
+++ b/frontend/src/components/pages/mypage/index.tsx
@@ -56,7 +56,7 @@ export const MyPagePage = () => {
 
         router.push('/signin')
         setIsSignedIn(undefined)
-        setProcessUser(undefined)
+        setProcessUser('')
         setChinchillaId(0)
         setHeaderName(undefined)
         setHeaderImage({ url: '' })

--- a/frontend/src/components/pages/mypage/index.tsx
+++ b/frontend/src/components/pages/mypage/index.tsx
@@ -15,7 +15,7 @@ import { debugLog } from 'src/lib/debug/debugLog'
 
 export const MyPagePage = () => {
   const router = useRouter()
-  const { setIsSignedIn, setCurrentUser, setProcessUser } = useContext(AuthContext)
+  const { setIsSignedIn, setProcessUser } = useContext(AuthContext)
   const { setChinchillaId, setHeaderName, setHeaderImage } = useContext(SelectedChinchillaIdContext)
 
   // 手続き
@@ -56,7 +56,6 @@ export const MyPagePage = () => {
 
         router.push('/signin')
         setIsSignedIn(undefined)
-        setCurrentUser(undefined)
         setProcessUser(undefined)
         setChinchillaId(0)
         setHeaderName(undefined)

--- a/frontend/src/components/pages/mypage/index.tsx
+++ b/frontend/src/components/pages/mypage/index.tsx
@@ -55,10 +55,10 @@ export const MyPagePage = () => {
         Cookies.remove('_uid')
 
         router.push('/signin')
-        setIsSignedIn(undefined)
+        setIsSignedIn(false)
         setProcessUser('')
         setChinchillaId(0)
-        setHeaderName(undefined)
+        setHeaderName('')
         setHeaderImage({ url: '' })
         debugLog('ログアウト:', '成功')
       } else {

--- a/frontend/src/components/pages/signin/index.tsx
+++ b/frontend/src/components/pages/signin/index.tsx
@@ -21,7 +21,7 @@ import type { SignInType } from 'src/types/auth'
 
 export const SignInPage = () => {
   const router = useRouter()
-  const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
+  const { setIsSignedIn } = useContext(AuthContext)
 
   const {
     handleSubmit,
@@ -47,9 +47,9 @@ export const SignInPage = () => {
         Cookies.set('_uid', res.headers['uid'])
 
         setIsSignedIn(true)
-        setCurrentUser(res.data.data)
-
         router.push('/mychinchilla')
+
+        debugLog('ログインユーザー:', res.data.data)
         debugLog('ログイン:', '成功')
       } else {
         debugLog('ログイン:', '失敗')

--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { AuthContext } from 'src/contexts/auth'
 
 export const Footer = () => {
-  const { isSignedIn, currentUser } = useContext(AuthContext)
+  const { isSignedIn } = useContext(AuthContext)
 
   const navigationBottomItems = [
     { key: 'mychinchilla', link: '/mychinchilla', icon: faHouse },
@@ -16,7 +16,8 @@ export const Footer = () => {
   return (
     <footer className="fixed bottom-0 z-50 h-12 w-full bg-dark-blue sm:h-16">
       <div className="mx-auto flex h-full max-w-screen-md items-center justify-between">
-        {isSignedIn && currentUser ? (
+        {/* ログイン時 */}
+        {isSignedIn === true && (
           <>
             {navigationBottomItems.map((item) => (
               <Link
@@ -31,7 +32,10 @@ export const Footer = () => {
               </Link>
             ))}
           </>
-        ) : (
+        )}
+
+        {/* 未ログイン時 */}
+        {isSignedIn === false && (
           <>
             <div>
               <Link

--- a/frontend/src/components/shared/Header/index.tsx
+++ b/frontend/src/components/shared/Header/index.tsx
@@ -19,7 +19,7 @@ export const Header = () => {
   const [allChinchillas, setAllChinchillas] = useState<MyChinchillaType[]>([])
 
   //ログインユーザーの状態管理（グローバル）
-  const { isSignedIn, currentUser } = useContext(AuthContext)
+  const { isSignedIn } = useContext(AuthContext)
 
   //選択中のチンチラの状態管理（グローバル）
   const {
@@ -65,7 +65,7 @@ export const Header = () => {
 
   // チンチラが登録されている場合は、先頭のチンチラをセット
   const fetch = async () => {
-    if (currentUser) {
+    if (isSignedIn === true) {
       try {
         const response = await getMyChinchillas()
         const res = response as AxiosResponse
@@ -87,7 +87,7 @@ export const Header = () => {
   // ログイン時に先頭のチンチラをセット
   useEffect(() => {
     fetch()
-  }, [currentUser])
+  }, [isSignedIn])
 
   return (
     <header className="fixed top-0 z-50 h-16 w-full bg-dark-blue">
@@ -100,13 +100,13 @@ export const Header = () => {
               width="100"
               height="48"
               alt="サービス名"
-              className={`my-2 ml-2 ${isSignedIn === true && currentUser && 'hidden sm:block'}`}
+              className={`my-2 ml-2 ${isSignedIn === true && 'hidden sm:block'}`}
             />
           </div>
         </Link>
 
         {/* ログイン時 */}
-        {isSignedIn === true && currentUser && (
+        {isSignedIn === true && (
           <>
             {/* 選択中のチンチラ */}
             <DisplaySelectChinchilla
@@ -140,7 +140,7 @@ export const Header = () => {
         )}
 
         {/* 未ログイン時 */}
-        {isSignedIn === false && currentUser === null && (
+        {isSignedIn === false && (
           <div className="flex h-full items-center">
             {userLinkItems.map((item) => (
               <Link

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -13,7 +13,7 @@ export const AuthContext = createContext<AuthContextType>(defaultAuthContextValu
 //_app.jsにエクスポートして、全体の親にする
 export const AuthProvider = ({ children }: Props) => {
   const [isSignedIn, setIsSignedIn] = useState<boolean | undefined>(undefined)
-  const [processUser, setProcessUser] = useState<string | null | undefined>(undefined)
+  const [processUser, setProcessUser] = useState<string>('')
   const value = {
     isSignedIn,
     setIsSignedIn,

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -13,13 +13,10 @@ export const AuthContext = createContext<AuthContextType>(defaultAuthContextValu
 //_app.jsにエクスポートして、全体の親にする
 export const AuthProvider = ({ children }: Props) => {
   const [isSignedIn, setIsSignedIn] = useState<boolean | undefined>(undefined)
-  const [currentUser, setCurrentUser] = useState<string | null | undefined>(undefined)
   const [processUser, setProcessUser] = useState<string | null | undefined>(undefined)
   const value = {
     isSignedIn,
     setIsSignedIn,
-    currentUser,
-    setCurrentUser,
     processUser,
     setProcessUser
   }
@@ -32,12 +29,10 @@ export const AuthProvider = ({ children }: Props) => {
 
       if (res?.data.isLogin === true) {
         setIsSignedIn(true)
-        setCurrentUser(res?.data.data)
 
         debugLog('ログインユーザー:', res?.data.data)
       } else {
         setIsSignedIn(false)
-        setCurrentUser(null)
         debugLog('ログインユーザー:', 'No current user')
       }
     } catch (err) {

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -15,8 +15,6 @@ export type ResetPasswordType = { password: string; passwordConfirmation: string
 export type AuthContextType = {
   isSignedIn: boolean | undefined // true: ログイン中, false: 未ログイン. undefined: 未確認
   setIsSignedIn: (isSignedIn: boolean | undefined) => void
-  currentUser: string | null | undefined // string: ユーザー情報, null: 未ログイン, undefined: 未確認
-  setCurrentUser: (currentUser: string | null | undefined) => void
   processUser: string | null | undefined // string: ユーザー情報, null: 未ログイン, undefined: 未確認
   setProcessUser: (processUser: string | null | undefined) => void
 }
@@ -24,8 +22,6 @@ export type AuthContextType = {
 export const defaultAuthContextValue: AuthContextType = {
   isSignedIn: undefined,
   setIsSignedIn: () => {},
-  currentUser: undefined,
-  setCurrentUser: () => {},
   processUser: undefined,
   setProcessUser: () => {}
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -15,13 +15,13 @@ export type ResetPasswordType = { password: string; passwordConfirmation: string
 export type AuthContextType = {
   isSignedIn: boolean | undefined // true: ログイン中, false: 未ログイン. undefined: 未確認
   setIsSignedIn: (isSignedIn: boolean | undefined) => void
-  processUser: string | null | undefined // string: ユーザー情報, null: 未ログイン, undefined: 未確認
-  setProcessUser: (processUser: string | null | undefined) => void
+  processUser: string
+  setProcessUser: (processUser: string) => void
 }
 
 export const defaultAuthContextValue: AuthContextType = {
   isSignedIn: undefined,
   setIsSignedIn: () => {},
-  processUser: undefined,
+  processUser: '',
   setProcessUser: () => {}
 }


### PR DESCRIPTION
# 説明
以下のとおり不要なグローバルstateの削除し、ヘッダー・フッターの出し分けロジックを修正しました。


### 修正前：
- グローバルで管理しているログイン中ユーザー「currentUser」について、ログイン時、ログアウト時、初回レンダリング時以外に確認することがないため、グローバルで管理する意義が乏しい。
- ログイン状態の状態管理は別のグローバルstateで行っており、「currentUser」と役割が重複する。

### 修正後：
- 「currentUser」を削除しました。
- 上記修正に伴い、ログイン状態によるヘッダー・フッターの出し分けのロジックを修正しました。

### 修正理由：
- 不要な状態管理をなくし、ユーザーへの負担を減らすため。

## 実装概要
- currentUserの状態管理を削除 fc32e9a
- 上記修正に伴い、ログイン状態によるヘッダー・フッターの出し分けのロジックを修正 d527edc df50b21

# スクリーンショット

| 実装前 | 実装後 |
| ------------- | ------------- |
|  |   |

# 変更のタイプ
- [ ] 新機能
- [x] 修正全般
- [ ] デザイン・UI/UX
- [ ] リファクタリング
